### PR TITLE
Add Users rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       "devDependencies": {
         "@arethetypeswrong/core": "^0.18.2",
         "@biomejs/biome": "2.4.11",
+        "@fast-check/vitest": "^0.4.0",
+        "fast-check": "^4.6.0",
         "publint": "^0.3.18",
         "tsdown": "^0.21.7",
         "typescript": "^5.8.3",
@@ -346,6 +348,29 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fast-check/vitest": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.4.0.tgz",
+      "integrity": "sha512-uv/x7EyT9/fRM0oxNP2myhxHtB1pZyHYMMLVoBGFff57cyINSGftPf3ZhqNzww7ajn/ufr/Bx6OPXX/TUFezmQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-check": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1036,6 +1061,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1538,6 +1586,23 @@
       "funding": {
         "url": "https://bjornlu.com/sponsor"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quansync": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "devDependencies": {
     "@arethetypeswrong/core": "^0.18.2",
     "@biomejs/biome": "2.4.11",
+    "@fast-check/vitest": "^0.4.0",
+    "fast-check": "^4.6.0",
     "publint": "^0.3.18",
     "tsdown": "^0.21.7",
     "typescript": "^5.8.3",

--- a/src/csv.test.ts
+++ b/src/csv.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeCsvHeaders,
   validateCsvData,
   validateCsvHeaders,
-} from '../src/csv';
+} from './csv';
 
 describe('normalizeCsvData', () => {
   it('should map alias keys to their canonical field names', () => {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -17,6 +17,7 @@ const csvFieldMap: Record<string, string> = {
   class: 'class',
 };
 
+/** @deprecated */
 export const normalizeCsvData = (
   data: Record<string, unknown>,
 ): Record<string, unknown> => {
@@ -30,10 +31,12 @@ export const normalizeCsvData = (
   return normalized;
 };
 
+/** @deprecated */
 export const normalizeCsvHeaders = (headers: string[]): string[] => {
   return headers.map((header) => header.toLowerCase().trim());
 };
 
+/** @deprecated */
 export const validateCsvData = <T>(
   schema: z.ZodSchema<T>,
   data: unknown[],
@@ -73,6 +76,7 @@ export const validateCsvData = <T>(
   };
 };
 
+/** @deprecated */
 export const validateCsvHeaders = (
   headers: string[],
   requiredHeaders: string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   validateCsvData,
   validateCsvHeaders,
 } from './csv';
+import { UserCsvSchema } from './user-csv';
 import { parseCommaSeparated } from './users';
 import {
   AddUsersCsvSchema,
@@ -553,6 +554,7 @@ export {
   StatSchema,
   TimestampSchema,
   UserClaimsSchema,
+  UserCsvSchema,
   UserLegalSchema,
   UserSchema,
   validateAddUsersCsv,
@@ -603,5 +605,6 @@ export type SchoolType = z.infer<typeof SchoolSchema>;
 export type StatType = z.infer<typeof StatSchema>;
 export type TimestampType = z.infer<typeof TimestampSchema>;
 export type UserClaimsType = z.infer<typeof UserClaimsSchema>;
+export type UserCsvType = z.infer<typeof UserCsvSchema>;
 export type UserLegalType = z.infer<typeof UserLegalSchema>;
 export type UserType = z.infer<typeof UserSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import {
 import { LinkUsersCsvSchema, validateLinkUsersCsv } from './users-link';
 
 // Type alias for Firestore Timestamp
+// @CC: "To check whether this is compatible with firestore - they encode
+// this using seconds and nanoseconds and it usually has to be converted"
 const TimestampSchema = z.iso.datetime();
 
 const LatLonSourceSchema = z.enum(['gps', 'h3_center', 'approximate']);
@@ -123,6 +125,8 @@ const LocationSchema = z
 const OrgRefMapSchema = z.object({
   classes: z.array(z.string()),
   districts: z.array(z.string()),
+  // @CC: "I don't think we actually ever use families? This is ROAR legacy
+  // - to confirm with team
   families: z.array(z.string()),
   groups: z.array(z.string()),
   schools: z.array(z.string()),
@@ -186,6 +190,7 @@ const AdministrationSchema = z.object({
   dateCreated: TimestampSchema,
   dateOpened: TimestampSchema,
   districts: z.array(z.string()),
+  // @CC: "Flagging for families discussion"
   families: z.array(z.string()),
   groups: z.array(z.string()),
   legal: LegalInfoSchema,
@@ -209,6 +214,7 @@ const AssignedOrgSchema = z.object({
   legal: LegalInfoSchema,
   name: z.string(),
   orgId: z.string(),
+  // @CC: "Flagging for families discussion"
   orgType: z.enum(['classes', 'districts', 'families', 'groups', 'schools']),
   publicName: z.string(),
   testData: z.boolean(),
@@ -267,6 +273,9 @@ const AssignmentAssessmentSchema = z.object({
 });
 
 // Structure for Claims within UserClaims
+// @CC: "I guess we still need this because we haven't gotten around to it
+// yet - but we are going to remove the use of the userClaims collection
+// entirely (we should be relying on custom auth claims instead)"
 const ClaimsSchema = z.object({
   adminOrgs: OrgRefMapSchema,
   adminUid: z.string().optional(),
@@ -489,6 +498,9 @@ const CreateOrgSchema = OrgSchema.pick({
   siteId: z.string().optional(),
 });
 
+// @CC: "Will this fail/reject csvs that have headers that aren't in one of
+// these three lists? I think we have sites that are managing their files with
+// other columns, so we need to have plans to ignore anything"
 const CsvHeadersSchema = z.object({
   headers: z.array(z.string()),
   requiredHeaders: z.array(z.string()),

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,9 @@ export {
 };
 
 export type AddUserCsvHeaderType = z.infer<typeof AddUserCsvHeaderSchema>;
+/** @deprecated */
 export type AddUsersCsvType = z.infer<typeof AddUsersCsvSchema>;
+/** @deprecated */
 export type AddUsersSubmitType = z.infer<typeof AddUsersSubmitSchema>;
 export type AdminDataType = z.infer<typeof AdminDataSchema>;
 export type AdministrationType = z.infer<typeof AdministrationSchema>;
@@ -596,6 +598,7 @@ export type CreateGroupType = z.infer<typeof CreateGroupSchema>;
 export type CreateOrgType = z.infer<typeof CreateOrgSchema>;
 export type CreateSchoolType = z.infer<typeof CreateSchoolSchema>;
 export type CreateUserType = z.infer<typeof CreateUserSchema>;
+/** @deprecated */
 export type CsvHeadersType = z.infer<typeof CsvHeadersSchema>;
 export type DistrictType = z.infer<typeof DistrictSchema>;
 export type H3CellType = z.infer<typeof H3CellSchema>;
@@ -603,6 +606,7 @@ export type GroupType = z.infer<typeof GroupSchema>;
 export type LatLonSourceType = z.infer<typeof LatLonSourceSchema>;
 export type LegalInfoType = z.infer<typeof LegalInfoSchema>;
 export type LegalType = z.infer<typeof LegalSchema>;
+/** @deprecated */
 export type LinkUsersCsvType = z.infer<typeof LinkUsersCsvSchema>;
 export type LocationType = z.infer<typeof LocationSchema>;
 export type OrgAssociationMapType = z.infer<typeof OrgAssociationMapSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,6 +506,7 @@ const CreateOrgSchema = OrgSchema.pick({
 // @CC: "Will this fail/reject csvs that have headers that aren't in one of
 // these three lists? I think we have sites that are managing their files with
 // other columns, so we need to have plans to ignore anything"
+/** @deprecated */
 const CsvHeadersSchema = z.object({
   headers: z.array(z.string()),
   requiredHeaders: z.array(z.string()),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ import {
   validateCsvData,
   validateCsvHeaders,
 } from './csv';
-import { UserCsvSchema } from './user-csv';
+import {
+  AddUserCsvHeaderSchema,
+  combineUserCsvIssues,
+  UserCsvSchema,
+} from './user-csv';
 import { parseCommaSeparated } from './users';
 import {
   AddUsersCsvSchema,
@@ -516,6 +520,7 @@ const locationDocId = (
 };
 
 export {
+  AddUserCsvHeaderSchema,
   AddUsersCsvSchema,
   AddUsersSubmitSchema,
   AdminDataSchema,
@@ -534,6 +539,7 @@ export {
   CreateSchoolSchema,
   CreateUserSchema,
   CsvHeadersSchema,
+  combineUserCsvIssues,
   DistrictSchema,
   GroupSchema,
   H3CellSchema,
@@ -565,6 +571,7 @@ export {
   validateLinkUsersCsv,
 };
 
+export type AddUserCsvHeaderType = z.infer<typeof AddUserCsvHeaderSchema>;
 export type AddUsersCsvType = z.infer<typeof AddUsersCsvSchema>;
 export type AddUsersSubmitType = z.infer<typeof AddUsersSubmitSchema>;
 export type AdminDataType = z.infer<typeof AdminDataSchema>;

--- a/src/issues.test.ts
+++ b/src/issues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { combineIssues, formatIssueFields } from '../src/issues';
+import { combineIssues, formatIssueFields } from './issues';
 
 const makeIssue = (path: (string | number)[], message: string): z.ZodIssue => ({
   code: z.ZodIssueCode.custom,

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 
+/** @deprecated */
 export const combineIssues = (
   issues: z.ZodIssue[],
 ): Array<{ field: string; message: string }> => {

--- a/src/user-csv.test.ts
+++ b/src/user-csv.test.ts
@@ -15,7 +15,7 @@ import {
   TeacherUserCsvRow,
   UserCsvRowBase,
   UserCsvSchema,
-} from '../src/user-csv';
+} from './user-csv';
 
 /** Fixture: returns a minimal zod issue */
 const $makeIssue = (

--- a/src/user-csv.test.ts
+++ b/src/user-csv.test.ts
@@ -798,6 +798,18 @@ describe('UserCsvSchema', () => {
     ).not.toThrow();
   });
 
+  it('rejects a row w/ an unknown userType', () => {
+    const result = UserCsvSchema.safeParse([
+      { ...$validChildRow, id: 'user-1', userType: 'unknown' },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_union');
+    expect(result.error!.issues[0].message).toEqual(
+      'Must be caregiver, child, or teacher',
+    );
+  });
+
   it('rejects a row with undefined userType', () => {
     const result = UserCsvSchema.safeParse([
       { ...$validChildRow, userType: undefined },

--- a/src/user-csv.ts
+++ b/src/user-csv.ts
@@ -1,18 +1,53 @@
 /**
- * Zod schemas for validating UserCsv rows
+ * Zod schemas for validating UserCsv headers and rows
  *
- * The main entry point is `UserCsvSchema`, which validates a list of UserCsv
- * rows, where each row is a `Record<string, string>`.
+ * To validate the headers of a UserCsv file, use `AddUserCsvHeaderSchema`.
+ *
+ * To validate the rows of a UserCsv file, use `UserCsvSchema`.
  *
  * To keep separation of concerns such that this library only handles side-
  * effect-free type coercion and validation, callers are responsible for
  * parsing CSV files upstream. If a field is empty in the file, it should be
  * passed as an empty string, not `undefined` or `null`.
- *
- * @TODO: Where should CSV sanitization happen? Maybe it's already handled
- * upstream by PapaParse?
  */
 import * as z from 'zod';
+
+/** The maximum year for a child user */
+export const CHILD_YEAR_MAX = new Date().getFullYear() - 2;
+
+/** The minimum year for a child user */
+export const CHILD_YEAR_MIN = new Date().getFullYear() - 18;
+
+/** The required headers for the Add Users CSV file */
+export const REQUIRED_ADD_USER_CSV_HEADERS = [
+  'id',
+  'userType',
+  'month',
+  'year',
+  'school',
+  'class',
+  'cohort',
+];
+
+/**
+ * Schema for validating the headers of an Add Users CSV file
+ *
+ * Usage: `AddUserCsvHeaderSchema.safeParse(headers: string[])`
+ */
+export const AddUserCsvHeaderSchema = z.array(z.string()).check(
+  z.superRefine((headers, ctx) => {
+    for (const required of REQUIRED_ADD_USER_CSV_HEADERS) {
+      if (!headers.includes(required)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Missing required header`,
+          path: [required],
+          input: headers,
+        });
+      }
+    }
+  }),
+);
 
 /**
  * A string of comma-separated values that parses into a list of trimmed,
@@ -26,17 +61,29 @@ export const ListableString = z.string().transform((value) => {
 });
 
 /**
+ * A required string, i.e., not empty or whitespace-only
+ */
+export const NonEmptyString = (message: string = 'Required') => {
+  // NB: pipe() forces type check to abort on failure instead of
+  // running proceeding checks in parallel
+  return z.string().pipe(z.string().trim().nonempty(message));
+};
+
+/**
  * A string that coerces into a number (or `Number.NaN`), e.g.,
  * `"123"` -> `123`, `"foo"` -> `Number.NaN`
  */
-export const NumberString = z.string().transform(Number);
+export const NumberString = (message: string = 'Required') => {
+  // NB: NonEmptyString() prevents '' from being coerced to 0
+  return NonEmptyString(message).transform(Number);
+};
 
 /**
  * Base schema for all UserCsv rows
  */
 export const UserCsvRowBase = z
   .object({
-    id: z.string().trim().min(1),
+    id: NonEmptyString(),
     school: ListableString,
     class: ListableString,
     cohort: ListableString,
@@ -53,14 +100,12 @@ export const UserCsvRowBase = z
       const hasAtLeastOneGroup = hasSchoolClass || hasCohort;
       const hasBothGroupTypes = hasSchoolClass && hasCohort;
       if (!hasAtLeastOneGroup || hasBothGroupTypes) {
-        for (const field of ['school', 'class', 'cohort']) {
-          ctx.addIssue({
-            code: 'custom',
-            message: 'Must have either school and class OR cohort',
-            path: [field],
-            input: data,
-          });
-        }
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Must have either school and class OR cohort',
+          path: ['school|class|cohort'],
+          input: data,
+        });
       }
     }),
   )
@@ -78,8 +123,15 @@ export const CaregiverUserCsvRow = UserCsvRowBase.extend({
  */
 export const ChildUserCsvRow = UserCsvRowBase.extend({
   userType: z.literal('child'),
-  month: NumberString.pipe(z.int().min(1).max(12)),
-  year: NumberString.pipe(z.int().min(1000).max(9999)), // @TODO: Define range better?
+  month: NumberString('Required for child users').pipe(
+    z.int('Must be a number').min(1, 'Must be >=1').max(12, 'Must be <=12'),
+  ),
+  year: NumberString('Required for child users').pipe(
+    z
+      .int('Must be a number')
+      .min(CHILD_YEAR_MIN, `Must be >=${CHILD_YEAR_MIN}`)
+      .max(CHILD_YEAR_MAX, `Must be <=${CHILD_YEAR_MAX}`),
+  ),
   caregiverId: ListableString,
   teacherId: ListableString,
 }).superRefine((data, ctx) => {
@@ -88,14 +140,12 @@ export const ChildUserCsvRow = UserCsvRowBase.extend({
   const hasClasses = data.class && data.class.length > 1;
   const hasCohorts = data.cohort && data.cohort.length > 1;
   if (hasSchools || hasClasses || hasCohorts) {
-    for (const field of ['school', 'class', 'cohort']) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Must have only one group',
-        path: [field],
-        input: data,
-      });
-    }
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Must have only one group',
+      path: ['school|class|cohort'],
+      input: data,
+    });
   }
 });
 
@@ -113,15 +163,66 @@ export const TeacherUserCsvRow = UserCsvRowBase.extend({
  */
 export const UserCsvSchema = z
   .array(
-    z.discriminatedUnion('userType', [
-      CaregiverUserCsvRow,
-      ChildUserCsvRow,
-      TeacherUserCsvRow,
-    ]),
+    z.discriminatedUnion(
+      'userType',
+      [CaregiverUserCsvRow, ChildUserCsvRow, TeacherUserCsvRow],
+      { message: 'Must be caregiver, child, or teacher' },
+    ),
   )
   .check(
-    z.superRefine((_data, _ctx) => {
-      // @TODO: inter-row validation
-      // enforce unique ids?
+    z.superRefine((data, ctx) => {
+      const seen = new Map<string, number[]>();
+      data.forEach((row, idx) => {
+        if (row.id === '') return;
+        const rows = seen.get(row.id) ?? [];
+        rows.push(idx);
+        seen.set(row.id, rows);
+      });
+
+      for (const rowIdxs of seen.values()) {
+        if (rowIdxs.length < 2) continue;
+        rowIdxs.forEach((idx) => {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'Must be unique',
+            path: [idx, 'id'],
+            input: data[idx],
+          });
+        });
+      }
     }),
   );
+
+/**
+ * Combines UserCsv validation issues by field+message
+ * @param issues - The zod issues to combine
+ * @returns A list of messages and the rows that caused them
+ */
+export const combineUserCsvIssues = (
+  issues: z.core.$ZodIssue[],
+): Array<{ message: string; rowNums: number[] }> => {
+  const rowIssues = issues.filter((issue) => issue.path.length > 0);
+
+  const combined = new Map<string, { rows: Set<number>; idx: number }>();
+  rowIssues.forEach((issue, idx) => {
+    const path = [...issue.path];
+    const rowNum = Number(path.shift());
+    if (Number.isNaN(rowNum)) return;
+    const message = `${path.join('.')}: ${issue.message ?? 'Invalid'}`;
+
+    if (!combined.has(message)) {
+      combined.set(message, { rows: new Set(), idx });
+    }
+
+    combined.get(message)!.rows.add(rowNum);
+  });
+
+  return Array.from(combined.entries())
+    .sort((a, b) => a[1].idx - b[1].idx)
+    .map(([message, data]) => ({
+      message,
+      rowNums: Array.from(data.rows)
+        .sort((a, b) => a - b)
+        .map((v) => v + 2), // NB: offset for header row and 1-indexing
+    }));
+};

--- a/src/user-csv.ts
+++ b/src/user-csv.ts
@@ -1,10 +1,22 @@
 /**
- * Schemas for validating UserCsv rows
+ * Zod schemas for validating UserCsv rows
+ *
+ * The main entry point is `UserCsvSchema`, which validates a list of UserCsv
+ * rows, where each row is a `Record<string, string>`.
+ *
+ * To keep separation of concerns such that this library only handles side-
+ * effect-free type coercion and validation, callers are responsible for
+ * parsing CSV files upstream. If a field is empty in the file, it should be
+ * passed as an empty string, not `undefined` or `null`.
+ *
+ * @TODO: Where should CSV sanitization happen? Maybe it's already handled
+ * upstream by PapaParse?
  */
 import * as z from 'zod';
 
 /**
- * A string of comma-separated values
+ * A string of comma-separated values that parses into a list of trimmed,
+ * non-empty strings, e.g., `"foo,bar,baz"` -> `["foo","bar","baz"]`
  */
 export const ListableString = z.string().transform((value) => {
   return value
@@ -14,17 +26,24 @@ export const ListableString = z.string().transform((value) => {
 });
 
 /**
+ * A string that coerces into a number (or `Number.NaN`), e.g.,
+ * `"123"` -> `123`, `"foo"` -> `Number.NaN`
+ */
+export const NumberString = z.string().transform(Number);
+
+/**
  * Base schema for all UserCsv rows
  */
 export const UserCsvRowBase = z
   .object({
     id: z.string().trim().min(1),
-    school: ListableString.optional(),
-    class: ListableString.optional(),
-    cohort: ListableString.optional(),
+    school: ListableString,
+    class: ListableString,
+    cohort: ListableString,
   })
   .check(
     z.superRefine((data, ctx) => {
+      // All users must have either school+class xor cohort
       const hasSchoolClass =
         data.school &&
         data.school.length > 0 &&
@@ -45,7 +64,7 @@ export const UserCsvRowBase = z
       }
     }),
   )
-  .loose();
+  .loose(); // Pass through unknown props
 
 /**
  * A caregiver UserCsv row
@@ -59,10 +78,10 @@ export const CaregiverUserCsvRow = UserCsvRowBase.extend({
  */
 export const ChildUserCsvRow = UserCsvRowBase.extend({
   userType: z.literal('child'),
-  month: z.int().min(1).max(12),
-  year: z.int().min(1000).max(9999),
-  caregiverId: ListableString.optional(),
-  teacherId: ListableString.optional(),
+  month: NumberString.pipe(z.int().min(1).max(12)),
+  year: NumberString.pipe(z.int().min(1000).max(9999)), // @TODO: Define range better?
+  caregiverId: ListableString,
+  teacherId: ListableString,
 }).superRefine((data, ctx) => {
   // Children must have only one group
   const hasSchools = data.school && data.school.length > 1;
@@ -88,9 +107,11 @@ export const TeacherUserCsvRow = UserCsvRowBase.extend({
 });
 
 /**
- * A list of UserCsv rows
+ * A schema for validating a list of UserCsv rows
+ *
+ * Usage: `UserCsvSchema.safeParse(csvData: Record<string, string>[])`
  */
-export const UserCsv = z
+export const UserCsvSchema = z
   .array(
     z.discriminatedUnion('userType', [
       CaregiverUserCsvRow,
@@ -100,7 +121,7 @@ export const UserCsv = z
   )
   .check(
     z.superRefine((_data, _ctx) => {
-      // TODO inter-row validation
+      // @TODO: inter-row validation
+      // enforce unique ids?
     }),
   );
-export type UserCsv = z.infer<typeof UserCsv>;

--- a/src/user-csv.ts
+++ b/src/user-csv.ts
@@ -1,0 +1,106 @@
+/**
+ * Schemas for validating UserCsv rows
+ */
+import * as z from 'zod';
+
+/**
+ * A string of comma-separated values
+ */
+export const ListableString = z.string().transform((value) => {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+});
+
+/**
+ * Base schema for all UserCsv rows
+ */
+export const UserCsvRowBase = z
+  .object({
+    id: z.string().trim().min(1),
+    school: ListableString.optional(),
+    class: ListableString.optional(),
+    cohort: ListableString.optional(),
+  })
+  .check(
+    z.superRefine((data, ctx) => {
+      const hasSchoolClass =
+        data.school &&
+        data.school.length > 0 &&
+        data.class &&
+        data.class.length > 0;
+      const hasCohort = data.cohort && data.cohort.length > 0;
+      const hasAtLeastOneGroup = hasSchoolClass || hasCohort;
+      const hasBothGroupTypes = hasSchoolClass && hasCohort;
+      if (!hasAtLeastOneGroup || hasBothGroupTypes) {
+        for (const field of ['school', 'class', 'cohort']) {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'Must have either school and class OR cohort',
+            path: [field],
+            input: data,
+          });
+        }
+      }
+    }),
+  )
+  .loose();
+
+/**
+ * A caregiver UserCsv row
+ */
+export const CaregiverUserCsvRow = UserCsvRowBase.extend({
+  userType: z.literal('caregiver'),
+});
+
+/**
+ * A child UserCsv row
+ */
+export const ChildUserCsvRow = UserCsvRowBase.extend({
+  userType: z.literal('child'),
+  month: z.int().min(1).max(12),
+  year: z.int().min(1000).max(9999),
+  caregiverId: ListableString.optional(),
+  teacherId: ListableString.optional(),
+}).superRefine((data, ctx) => {
+  // Children must have only one group
+  const hasSchools = data.school && data.school.length > 1;
+  const hasClasses = data.class && data.class.length > 1;
+  const hasCohorts = data.cohort && data.cohort.length > 1;
+  if (hasSchools || hasClasses || hasCohorts) {
+    for (const field of ['school', 'class', 'cohort']) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Must have only one group',
+        path: [field],
+        input: data,
+      });
+    }
+  }
+});
+
+/**
+ * A teacher UserCsv row
+ */
+export const TeacherUserCsvRow = UserCsvRowBase.extend({
+  userType: z.literal('teacher'),
+});
+
+/**
+ * A list of UserCsv rows
+ */
+export const UserCsv = z
+  .array(
+    z.discriminatedUnion('userType', [
+      CaregiverUserCsvRow,
+      ChildUserCsvRow,
+      TeacherUserCsvRow,
+    ]),
+  )
+  .check(
+    z.superRefine((_data, _ctx) => {
+      // TODO inter-row validation
+    }),
+  );
+export type UserCsv = z.infer<typeof UserCsv>;

--- a/src/user-csv.ts
+++ b/src/user-csv.ts
@@ -171,6 +171,7 @@ export const UserCsvSchema = z
   )
   .check(
     z.superRefine((data, ctx) => {
+      // All users must have a unique id
       const seen = new Map<string, number[]>();
       data.forEach((row, idx) => {
         if (row.id === '') return;

--- a/src/users-add.test.ts
+++ b/src/users-add.test.ts
@@ -3,7 +3,7 @@ import {
   combineFieldErrors,
   detectMultipleSites,
   validateAddUsersFileUpload,
-} from '../src/users-add';
+} from './users-add';
 
 const validTeacher = { usertype: 'teacher', cohort: 'cohort1' };
 const validChild = {

--- a/src/users-add.ts
+++ b/src/users-add.ts
@@ -57,6 +57,7 @@ export const addChildUserRules = <T extends z.ZodType<AddUserBirthdateOutput>>(
     }),
   );
 
+/** @deprecated */
 export const AddUsersCsvSchema = addChildUserRules(
   z
     .object({
@@ -114,6 +115,7 @@ export const AddUsersCsvSchema = addChildUserRules(
     })),
 );
 
+/** @deprecated */
 export const AddUsersSubmitSchema = addChildUserRules(
   z.object({
     id: z.string().trim().optional(),
@@ -243,9 +245,11 @@ const normalizeFieldLabel = (field: string): string => {
   return field;
 };
 
+/** @deprecated */
 export const validateAddUsersCsv = (data: unknown[]) =>
   validateCsvData(AddUsersCsvSchema, data);
 
+/** @deprecated */
 export const validateAddUsersFileUpload = (
   parsedData: Record<string, unknown>[],
   shouldUsePermissions: boolean,
@@ -392,6 +396,7 @@ export const validateAddUsersFileUpload = (
   };
 };
 
+/** @deprecated */
 export const validateAddUsersSubmit = (
   data: unknown,
 ): {

--- a/src/users-add.ts
+++ b/src/users-add.ts
@@ -9,6 +9,9 @@ import {
 } from './users';
 
 interface AddUserBirthdateInput {
+  // @CC: "So here's where I think we want to clean up some ugliness around
+  // legacy ROAR terms (student, parent) vs ours (child, caregiver) - this
+  // mixes the two which is not great"
   userType: 'child' | 'parent' | 'teacher';
   month?: number | undefined;
   year?: number | undefined;
@@ -183,6 +186,8 @@ export const combineFieldErrors = (
     });
 };
 
+// @CC: "I think this is now impossible given the site selector (site used
+// to be a column in the csv file)"
 export const detectMultipleSites = (
   parsedData: Record<string, unknown>[],
 ): {
@@ -227,6 +232,9 @@ const getChildAgeErrorFields = (
 
   if (yearDiff > 18) return ['month', 'year'];
   if (yearDiff < 18) return [];
+  // @CC: "Wouldn't this send a month error to anyone born in the calendar
+  // year before the current month? Don't we just want a check that returns a
+  // month error if birthMonth>12 (or >=13)?"
   return currentMonth >= birthMonth ? ['month'] : [];
 };
 
@@ -349,6 +357,8 @@ export const validateAddUsersFileUpload = (
     });
   }
 
+  // @CC: "Just to flag that this and 301-303 should be removed once we've
+  // removed permissions"
   if (!shouldUsePermissions) {
     usersWithoutId.forEach((user) => {
       if (usersWithZodErrors.has(user)) return;

--- a/src/users-link.test.ts
+++ b/src/users-link.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LinkUsersCsvSchema, validateLinkUsersCsv } from '../src/users-link';
+import { LinkUsersCsvSchema, validateLinkUsersCsv } from './users-link';
 
 const validRow = { id: 'user-1', usertype: 'teacher', uid: 'uid-1' };
 

--- a/src/users-link.ts
+++ b/src/users-link.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { validateCsvData } from './csv';
 import { NormalizedUserTypeSchema } from './users';
 
+/** @deprecated */
 export const LinkUsersCsvSchema = z
   .object({
     id: z.string().min(1, 'ID is required').trim(),
@@ -15,5 +16,6 @@ export const LinkUsersCsvSchema = z
     userType: usertype,
   }));
 
+/** @deprecated */
 export const validateLinkUsersCsv = (data: unknown[]) =>
   validateCsvData(LinkUsersCsvSchema, data);

--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -5,7 +5,7 @@ import {
   NormalizedUserTypeSchema,
   parseCommaSeparated,
   YearSchema,
-} from '../src/users';
+} from './users';
 
 describe('parseCommaSeparated', () => {
   it('returns an empty array for undefined', () => {

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** @deprecated */
 export const parseCommaSeparated = (value: string | undefined): string[] => {
   if (!value) return [];
   return value

--- a/src/users.ts
+++ b/src/users.ts
@@ -27,6 +27,12 @@ export const MonthSchema = z
       .optional(),
   );
 
+// @CC: "There's some math done in users-add that could be moved here?
+// It's not just that this should be a four digit number; it's that the min max
+// range should be between currentYear-2 and currentYear-18 (i.e., child users
+// must be between 2years old and 18 years old - the current check already
+// doesn't take month into account, i.e., would reject a 17yo born in July
+// because their birth year is 2008)"
 export const YearSchema = z
   .union([z.string(), z.number(), z.undefined()])
   .transform((value) => {
@@ -42,6 +48,8 @@ export const YearSchema = z
       .optional(),
   );
 
+// @CC: "Why is this converting caregiver to parent? and not child to
+// student?"
 export const NormalizedUserTypeSchema = z
   .string()
   .trim()

--- a/tests/user-csv.test.ts
+++ b/tests/user-csv.test.ts
@@ -1,43 +1,65 @@
 import { fc, it } from '@fast-check/vitest';
 import { describe, expect } from 'vitest';
+import type * as z from 'zod';
 import {
+  AddUserCsvHeaderSchema,
   CaregiverUserCsvRow,
+  CHILD_YEAR_MAX,
+  CHILD_YEAR_MIN,
   ChildUserCsvRow,
+  combineUserCsvIssues,
   ListableString,
+  NonEmptyString,
   NumberString,
+  REQUIRED_ADD_USER_CSV_HEADERS,
   TeacherUserCsvRow,
   UserCsvRowBase,
   UserCsvSchema,
 } from '../src/user-csv';
 
+/** Fixture: returns a minimal zod issue */
+const $makeIssue = (
+  path: PropertyKey[],
+  message: string | undefined = 'Invalid',
+): z.core.$ZodIssue =>
+  ({
+    code: 'custom',
+    path,
+    message,
+    input: undefined,
+  }) as unknown as z.core.$ZodIssue;
+
+/** Arbitrary: a non-array value */
+const $nonArray = fc.anything().filter((v) => !Array.isArray(v));
+
 /** Arbitrary: a non-empty string (NB: trim-stable and comma-free so it
  *  produces exactly one ListableString part) */
-const nonEmptyString = fc
+const $nonEmptyString = fc
   .string({ minLength: 1 })
   .filter((s) => s.trim() === s && !s.includes(','));
 
 /** Arbitrary: a non-empty array of non-empty strings */
-const nonEmptyStringArray = fc.array(nonEmptyString, { minLength: 1 });
+const $nonEmptyStringArray = fc.array($nonEmptyString, { minLength: 1 });
 
 /** Arbitrary: a non-integer number value */
-const nonIntegerNumber = fc
+const $nonIntegerNumber = fc
   .float()
   .filter((n) => !Number.isInteger(n))
   .map(String);
 
 /** Arbitrary: a non-number string (e.g., "foo", "one") */
-const nonNumberString = fc.string().filter((v) => Number.isNaN(Number(v)));
+const $nonNumberString = fc.string().filter((v) => Number.isNaN(Number(v)));
 
 /** Arbitrary: a non-string value */
-const nonString = fc.anything().filter((v) => typeof v !== 'string');
+const $nonString = fc.anything().filter((v) => typeof v !== 'string');
 
 /** Arbitrary: a number string (e.g., "123", "123.456", "NaN") */
-const numberString = fc
+const $numberString = fc
   .oneof(fc.float(), fc.integer(), fc.constant('NaN'))
   .map(String);
 
 /** Fixture: a valid caregiver/teacher row to derive test fixtures from */
-const validAdultRow = {
+const $validAdultRow = {
   id: 'user-1',
   userType: undefined, // NB: must be defined by the test case
   month: '',
@@ -50,7 +72,7 @@ const validAdultRow = {
 };
 
 /** Fixture: a valid child row to derive test fixtures from */
-const validChildRow = {
+const $validChildRow = {
   id: 'user-1',
   userType: 'child',
   month: '1',
@@ -62,21 +84,91 @@ const validChildRow = {
   cohort: '',
 };
 
+describe('AddUserCsvHeaderSchema', () => {
+  it('accepts an array containing all required headers', () => {
+    expect(
+      AddUserCsvHeaderSchema.parse([...REQUIRED_ADD_USER_CSV_HEADERS]),
+    ).toEqual([...REQUIRED_ADD_USER_CSV_HEADERS]);
+  });
+
+  it('accepts extra headers beyond the required set', () => {
+    expect(
+      AddUserCsvHeaderSchema.parse([...REQUIRED_ADD_USER_CSV_HEADERS, 'foo']),
+    ).toEqual([...REQUIRED_ADD_USER_CSV_HEADERS, 'foo']);
+  });
+
+  it.prop({ v: $nonArray })('rejects non-arrays', ({ v }) => {
+    const result = AddUserCsvHeaderSchema.safeParse(v);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_type');
+    expect(result.error!.issues[0].path).toEqual([]);
+  });
+
+  it.prop({ v: $nonString })(
+    'rejects arrays containing non-string elements',
+    ({ v }) => {
+      const result = AddUserCsvHeaderSchema.safeParse([
+        ...REQUIRED_ADD_USER_CSV_HEADERS,
+        v,
+        v,
+      ]);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(2);
+      result.error!.issues.forEach((issue, idx) => {
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.path).toEqual([
+          REQUIRED_ADD_USER_CSV_HEADERS.length + idx,
+        ]);
+      });
+    },
+  );
+
+  REQUIRED_ADD_USER_CSV_HEADERS.forEach((header) => {
+    it(`rejects headers missing "${header}"`, () => {
+      const withoutHeader = REQUIRED_ADD_USER_CSV_HEADERS.filter(
+        (h) => h !== header,
+      );
+      const result = AddUserCsvHeaderSchema.safeParse(withoutHeader);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('custom');
+      expect(result.error!.issues[0].message).toEqual(
+        `Missing required header`,
+      );
+      expect(result.error!.issues[0].path).toEqual([header]);
+    });
+  });
+
+  it('rejects w/ multiple issues if multiple headers are missing', () => {
+    const result = AddUserCsvHeaderSchema.safeParse([]);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(
+      REQUIRED_ADD_USER_CSV_HEADERS.length,
+    );
+    result.error!.issues.forEach((issue, idx) => {
+      expect(issue.code).toEqual('custom');
+      expect(issue.message).toEqual(`Missing required header`);
+      expect(issue.path).toEqual([REQUIRED_ADD_USER_CSV_HEADERS[idx]]);
+    });
+  });
+});
+
 describe('ListableString', () => {
   it.prop({
-    parts: nonEmptyStringArray,
+    parts: $nonEmptyStringArray,
   })('parses comma-separated string into an array', ({ parts }) => {
     expect(ListableString.parse(parts.join(','))).toEqual(parts);
   });
 
   it.prop({
-    parts: nonEmptyStringArray,
+    parts: $nonEmptyStringArray,
   })('trims whitespace from each part', ({ parts }) => {
     expect(ListableString.parse(parts.join(' , '))).toEqual(parts);
   });
 
   it.prop({
-    parts: nonEmptyStringArray,
+    parts: $nonEmptyStringArray,
   })('filters out empty parts', ({ parts }) => {
     expect(ListableString.parse(parts.join(', ,,'))).toEqual(parts);
   });
@@ -85,36 +177,91 @@ describe('ListableString', () => {
     expect(ListableString.parse('')).toEqual([]);
   });
 
-  it.prop({ v: nonString })('rejects non-strings', ({ v }) => {
-    expect(() => ListableString.parse(v)).toThrow();
+  it.prop({ v: $nonString })('rejects non-strings', ({ v }) => {
+    const result = ListableString.safeParse(v);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_type');
+    expect(result.error!.issues[0].path).toEqual([]);
+  });
+});
+
+describe('NonEmptyString', () => {
+  it.prop({ v: $nonEmptyString })('accepts non-empty strings', ({ v }) => {
+    expect(() => NonEmptyString().parse(v)).not.toThrow();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(NonEmptyString().parse('  hello  ')).toEqual('hello');
+  });
+
+  it('rejects an empty string with the default message', () => {
+    const result = NonEmptyString().safeParse('');
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].message).toEqual('Required');
+  });
+
+  it('rejects a whitespace-only string with the default message', () => {
+    const result = NonEmptyString().safeParse('   ');
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].message).toEqual('Required');
+  });
+
+  it('uses a custom message when provided', () => {
+    const result = NonEmptyString('Name is required').safeParse('');
+    expect(result.success).toBe(false);
+    expect(result.error!.issues[0].message).toEqual('Name is required');
+  });
+
+  it.prop({ v: $nonString })('rejects non-strings', ({ v }) => {
+    const result = NonEmptyString().safeParse(v);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_type');
+    expect(result.error!.issues[0].path).toEqual([]);
   });
 });
 
 describe('NumberString', () => {
-  it.prop({ v: numberString })('coerces strings into numbers', ({ v }) => {
-    expect(NumberString.parse(v)).toEqual(Number(v));
+  it.prop({ v: $numberString })('coerces strings into numbers', ({ v }) => {
+    expect(NumberString().parse(v)).toEqual(Number(v));
   });
 
-  it.prop({ v: nonNumberString })(
+  it.prop({ v: $nonNumberString })(
     'coerces non-number strings into NaN',
     ({ v }) => {
-      expect(NumberString.parse(v)).toBeNaN();
+      expect(NumberString().parse(v)).toBeNaN();
     },
   );
 
-  it.prop({ v: nonString })('rejects non-strings', ({ v }) => {
-    expect(() => NumberString.parse(v)).toThrow();
+  it.prop({ v: $nonString })('rejects non-strings', ({ v }) => {
+    const result = NumberString().safeParse(v);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_type');
+    expect(result.error!.issues[0].path).toEqual([]);
+  });
+
+  it('rejects an empty string', () => {
+    const result = NumberString().safeParse('');
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('too_small');
+    expect(result.error!.issues[0].message).toEqual('Required');
+    expect(result.error!.issues[0].path).toEqual([]);
   });
 });
 
 describe('UserCsvRowBase', () => {
   it('accepts a valid row', () => {
-    expect(() => UserCsvRowBase.parse(validChildRow)).not.toThrow();
+    expect(() => UserCsvRowBase.parse($validChildRow)).not.toThrow();
   });
 
   it('keeps loose properties', () => {
     const result = UserCsvRowBase.safeParse({
-      ...validChildRow,
+      ...$validChildRow,
       site: 'site-1',
     });
     expect(result.success).toBe(true);
@@ -122,15 +269,15 @@ describe('UserCsvRowBase', () => {
   });
 
   describe('id validation', () => {
-    it.prop({ id: nonEmptyString })('accepts non-empty strings', ({ id }) => {
+    it.prop({ id: $nonEmptyString })('accepts non-empty strings', ({ id }) => {
       expect(() =>
-        UserCsvRowBase.parse({ ...validChildRow, id }),
+        UserCsvRowBase.parse({ ...$validChildRow, id }),
       ).not.toThrow();
     });
 
-    it.prop({ id: nonEmptyString })('trims whitespace', ({ id }) => {
+    it.prop({ id: $nonEmptyString })('trims whitespace', ({ id }) => {
       const result = UserCsvRowBase.safeParse({
-        ...validChildRow,
+        ...$validChildRow,
         id: ` ${id}  `,
       });
       expect(result.success).toBe(true);
@@ -138,30 +285,43 @@ describe('UserCsvRowBase', () => {
     });
 
     it('rejects an empty string', () => {
-      expect(() =>
-        UserCsvRowBase.parse({ ...validChildRow, id: '' }),
-      ).toThrow();
+      const result = UserCsvRowBase.safeParse({ ...$validChildRow, id: '' });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual('Required');
+      expect(result.error!.issues[0].path).toEqual(['id']);
     });
 
     it('rejects a whitespace-only string', () => {
-      expect(() =>
-        UserCsvRowBase.parse({ ...validChildRow, id: '   ' }),
-      ).toThrow();
+      const result = UserCsvRowBase.safeParse({
+        ...$validChildRow,
+        id: '   ',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual('Required');
+      expect(result.error!.issues[0].path).toEqual(['id']);
     });
 
-    it.prop({ id: nonString })('rejects non-strings', ({ id }) => {
-      expect(() => UserCsvRowBase.parse({ ...validChildRow, id })).toThrow();
+    it.prop({ id: $nonString })('rejects non-strings', ({ id }) => {
+      const result = UserCsvRowBase.safeParse({ ...$validChildRow, id });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('invalid_type');
+      expect(result.error!.issues[0].path).toEqual(['id']);
     });
   });
 
   describe('group validation (valid combinations)', () => {
     it.prop({
-      school: nonEmptyString,
-      _class: nonEmptyString, // NB: underscore avoids conflict w/ class property
+      school: $nonEmptyString,
+      _class: $nonEmptyString, // NB: underscore avoids conflict w/ class property
     })('accepts rows w/ school+class (no cohort)', ({ school, _class }) => {
       expect(() =>
         UserCsvRowBase.parse({
-          ...validChildRow,
+          ...$validChildRow,
           school,
           class: _class,
           cohort: '',
@@ -170,14 +330,14 @@ describe('UserCsvRowBase', () => {
     });
 
     it.prop({
-      schools: nonEmptyStringArray,
-      classes: nonEmptyStringArray,
+      schools: $nonEmptyStringArray,
+      classes: $nonEmptyStringArray,
     })(
       'accepts rows w/ schools+classes (no cohort)',
       ({ schools, classes }) => {
         expect(() =>
           UserCsvRowBase.parse({
-            ...validChildRow,
+            ...$validChildRow,
             school: schools.join(','),
             class: classes.join(','),
             cohort: '',
@@ -186,12 +346,12 @@ describe('UserCsvRowBase', () => {
       },
     );
 
-    it.prop({ cohort: nonEmptyString })(
+    it.prop({ cohort: $nonEmptyString })(
       'accepts rows w/ cohort (no school+class)',
       ({ cohort }) => {
         expect(() =>
           UserCsvRowBase.parse({
-            ...validChildRow,
+            ...$validChildRow,
             school: '',
             class: '',
             cohort,
@@ -200,12 +360,12 @@ describe('UserCsvRowBase', () => {
       },
     );
 
-    it.prop({ cohorts: nonEmptyStringArray })(
+    it.prop({ cohorts: $nonEmptyStringArray })(
       'accepts rows w/ cohorts (no school+class)',
       ({ cohorts }) => {
         expect(() =>
           UserCsvRowBase.parse({
-            ...validChildRow,
+            ...$validChildRow,
             school: '',
             class: '',
             cohort: cohorts.join(','),
@@ -217,59 +377,79 @@ describe('UserCsvRowBase', () => {
 
   describe('group validation (invalid combinations)', () => {
     it('rejects a row w/ no group', () => {
-      expect(() =>
-        UserCsvRowBase.parse({
-          ...validChildRow,
-          school: '',
-          class: '',
-          cohort: '',
-        }),
-      ).toThrow();
+      const result = UserCsvRowBase.safeParse({
+        ...$validChildRow,
+        school: '',
+        class: '',
+        cohort: '',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('custom');
+      expect(result.error!.issues[0].message).toEqual(
+        'Must have either school and class OR cohort',
+      );
+      expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
     });
 
-    it.prop({ school: nonEmptyString })(
+    it.prop({ school: $nonEmptyString })(
       'rejects rows w/ school but no class',
       ({ school }) => {
-        expect(() =>
-          UserCsvRowBase.parse({
-            ...validChildRow,
-            school,
-            class: '',
-            cohort: '',
-          }),
-        ).toThrow();
+        const result = UserCsvRowBase.safeParse({
+          ...$validChildRow,
+          school,
+          class: '',
+          cohort: '',
+        });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('custom');
+        expect(result.error!.issues[0].message).toEqual(
+          'Must have either school and class OR cohort',
+        );
+        expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
       },
     );
 
-    it.prop({ _class: nonEmptyString })(
+    it.prop({ _class: $nonEmptyString })(
       'rejects rows w/ class but no school',
       ({ _class }) => {
-        expect(() =>
-          UserCsvRowBase.parse({
-            ...validChildRow,
-            school: '',
-            class: _class,
-            cohort: '',
-          }),
-        ).toThrow();
+        const result = UserCsvRowBase.safeParse({
+          ...$validChildRow,
+          school: '',
+          class: _class,
+          cohort: '',
+        });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('custom');
+        expect(result.error!.issues[0].message).toEqual(
+          'Must have either school and class OR cohort',
+        );
+        expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
       },
     );
 
     it.prop({
-      school: nonEmptyString,
-      _class: nonEmptyString,
-      cohort: nonEmptyString,
+      school: $nonEmptyString,
+      _class: $nonEmptyString,
+      cohort: $nonEmptyString,
     })(
       'rejects rows w/ both school+class and cohort',
       ({ school, _class, cohort }) => {
-        expect(() =>
-          UserCsvRowBase.parse({
-            ...validChildRow,
-            school,
-            class: _class,
-            cohort,
-          }),
-        ).toThrow();
+        const result = UserCsvRowBase.safeParse({
+          ...$validChildRow,
+          school,
+          class: _class,
+          cohort,
+        });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('custom');
+        expect(result.error!.issues[0].message).toEqual(
+          'Must have either school and class OR cohort',
+        );
+        expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
       },
     );
   });
@@ -278,36 +458,24 @@ describe('UserCsvRowBase', () => {
 describe('CaregiverUserCsvRow', () => {
   it('accepts a valid row', () => {
     expect(() =>
-      CaregiverUserCsvRow.parse({ ...validAdultRow, userType: 'caregiver' }),
+      CaregiverUserCsvRow.parse({ ...$validAdultRow, userType: 'caregiver' }),
     ).not.toThrow();
   });
 
   it('keeps loose properties', () => {
     const result = CaregiverUserCsvRow.safeParse({
-      ...validAdultRow,
+      ...$validAdultRow,
       userType: 'caregiver',
       site: 'site-1',
     });
     expect(result.success).toBe(true);
     expect(result.data?.site).toEqual('site-1');
   });
-
-  it('rejects rows missing expected fields', () => {
-    ['id', 'userType', 'school', 'class', 'cohort'].forEach((key) => {
-      expect(() =>
-        CaregiverUserCsvRow.parse({
-          ...validAdultRow,
-          userType: 'caregiver',
-          [key]: undefined,
-        }),
-      ).toThrow();
-    });
-  });
 });
 
 describe('ChildUserCsvRow', () => {
   it('accepts a valid row', () => {
-    expect(() => ChildUserCsvRow.parse({ ...validChildRow })).not.toThrow();
+    expect(() => ChildUserCsvRow.parse({ ...$validChildRow })).not.toThrow();
   });
 
   describe('month validation', () => {
@@ -315,91 +483,153 @@ describe('ChildUserCsvRow', () => {
       'accepts valid months (1-12)',
       ({ month }) => {
         expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, month }),
+          ChildUserCsvRow.parse({ ...$validChildRow, month }),
         ).not.toThrow();
       },
     );
 
+    it('rejects an empty string', () => {
+      const result = ChildUserCsvRow.safeParse({
+        ...$validChildRow,
+        month: '',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual(
+        'Required for child users',
+      );
+      expect(result.error!.issues[0].path).toEqual(['month']);
+    });
+
     it.prop({
       month: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 0 }).map(String),
     })('rejects months below 1', ({ month }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, month }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, month });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual('Must be >=1');
+      expect(result.error!.issues[0].path).toEqual(['month']);
     });
 
     it.prop({
       month: fc.integer({ min: 13, max: Number.MAX_SAFE_INTEGER }).map(String),
     })('rejects months above 12', ({ month }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, month }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, month });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_big');
+      expect(result.error!.issues[0].message).toEqual('Must be <=12');
+      expect(result.error!.issues[0].path).toEqual(['month']);
     });
 
-    it.prop({ month: nonString })('rejects non-strings', ({ month }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, month }),
-      ).toThrow();
+    it.prop({ month: $nonString })('rejects non-strings', ({ month }) => {
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, month });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('invalid_type');
+      expect(result.error!.issues[0].path).toEqual(['month']);
     });
 
-    it.prop({ month: nonIntegerNumber })(
+    it.prop({ month: $nonIntegerNumber })(
       'rejects non-integer numbers',
       ({ month }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, month }),
-        ).toThrow();
+        const result = ChildUserCsvRow.safeParse({ ...$validChildRow, month });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('invalid_type');
+        expect(result.error!.issues[0].message).toEqual('Must be a number');
+        expect(result.error!.issues[0].path).toEqual(['month']);
       },
     );
 
-    it.prop({ month: nonNumberString })(
+    it.prop({ month: $nonNumberString })(
       'rejects non-number strings',
       ({ month }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, month }),
-        ).toThrow();
+        const result = ChildUserCsvRow.safeParse({ ...$validChildRow, month });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('invalid_type');
+        expect(result.error!.issues[0].message).toEqual('Must be a number');
+        expect(result.error!.issues[0].path).toEqual(['month']);
       },
     );
   });
 
   describe('year validation', () => {
-    it.prop({ year: fc.integer({ min: 1000, max: 9999 }).map(String) })(
-      'accepts valid years (1000-9999)',
-      ({ year }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, year }),
-        ).not.toThrow();
-      },
-    );
-
     it.prop({
-      year: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 999 }).map(String),
-    })('rejects years below 1000', ({ year }) => {
-      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
+      year: fc
+        .integer({ min: CHILD_YEAR_MIN, max: CHILD_YEAR_MAX })
+        .map(String),
+    })('accepts valid years (CHILD_YEAR_MIN-CHILD_YEAR_MAX)', ({ year }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...$validChildRow, year }),
+      ).not.toThrow();
+    });
+
+    it('rejects an empty string', () => {
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, year: '' });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual(
+        'Required for child users',
+      );
+      expect(result.error!.issues[0].path).toEqual(['year']);
     });
 
     it.prop({
       year: fc
-        .integer({ min: 10000, max: Number.MAX_SAFE_INTEGER })
+        .integer({ min: Number.MIN_SAFE_INTEGER, max: CHILD_YEAR_MIN - 1 })
         .map(String),
-    })('rejects years above 9999', ({ year }) => {
-      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
+    })('rejects years below CHILD_YEAR_MIN', ({ year }) => {
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, year });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_small');
+      expect(result.error!.issues[0].message).toEqual(
+        `Must be >=${CHILD_YEAR_MIN}`,
+      );
+      expect(result.error!.issues[0].path).toEqual(['year']);
     });
 
-    it.prop({ year: nonIntegerNumber })(
+    it.prop({
+      year: fc
+        .integer({ min: CHILD_YEAR_MAX + 1, max: Number.MAX_SAFE_INTEGER })
+        .map(String),
+    })('rejects years above CHILD_YEAR_MAX', ({ year }) => {
+      const result = ChildUserCsvRow.safeParse({ ...$validChildRow, year });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('too_big');
+      expect(result.error!.issues[0].message).toEqual(
+        `Must be <=${CHILD_YEAR_MAX}`,
+      );
+      expect(result.error!.issues[0].path).toEqual(['year']);
+    });
+
+    it.prop({ year: $nonIntegerNumber })(
       'rejects non-integer numbers',
       ({ year }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, year }),
-        ).toThrow();
+        const result = ChildUserCsvRow.safeParse({ ...$validChildRow, year });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('invalid_type');
+        expect(result.error!.issues[0].message).toEqual('Must be a number');
+        expect(result.error!.issues[0].path).toEqual(['year']);
       },
     );
 
-    it.prop({ year: nonNumberString })(
+    it.prop({ year: $nonNumberString })(
       'rejects non-number strings',
       ({ year }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, year }),
-        ).toThrow();
+        const result = ChildUserCsvRow.safeParse({ ...$validChildRow, year });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('invalid_type');
+        expect(result.error!.issues[0].message).toEqual('Must be a number');
+        expect(result.error!.issues[0].path).toEqual(['year']);
       },
     );
   });
@@ -407,15 +637,15 @@ describe('ChildUserCsvRow', () => {
   describe('caregiverId validation', () => {
     it('accepts an empty caregiverId', () => {
       expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, caregiverId: '' }),
+        ChildUserCsvRow.parse({ ...$validChildRow, caregiverId: '' }),
       ).not.toThrow();
     });
 
-    it.prop({ parts: nonEmptyStringArray })(
+    it.prop({ parts: $nonEmptyStringArray })(
       'accepts a comma-separated string and parses it into an array',
       ({ parts }) => {
         const result = ChildUserCsvRow.safeParse({
-          ...validChildRow,
+          ...$validChildRow,
           caregiverId: parts.join(','),
         });
         expect(result.success).toBe(true);
@@ -424,26 +654,31 @@ describe('ChildUserCsvRow', () => {
     );
 
     it.prop({
-      caregiverId: nonString,
+      caregiverId: $nonString,
     })('rejects non-strings', ({ caregiverId }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, caregiverId }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({
+        ...$validChildRow,
+        caregiverId,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('invalid_type');
+      expect(result.error!.issues[0].path).toEqual(['caregiverId']);
     });
   });
 
   describe('teacherId validation', () => {
     it('accepts an empty teacherId', () => {
       expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, teacherId: '' }),
+        ChildUserCsvRow.parse({ ...$validChildRow, teacherId: '' }),
       ).not.toThrow();
     });
 
-    it.prop({ parts: nonEmptyStringArray })(
+    it.prop({ parts: $nonEmptyStringArray })(
       'accepts a comma-separated string and parses it into an array',
       ({ parts }) => {
         const result = ChildUserCsvRow.safeParse({
-          ...validChildRow,
+          ...$validChildRow,
           teacherId: parts.join(','),
         });
         expect(result.success).toBe(true);
@@ -452,21 +687,26 @@ describe('ChildUserCsvRow', () => {
     );
 
     it.prop({
-      teacherId: nonString,
+      teacherId: $nonString,
     })('rejects non-strings', ({ teacherId }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, teacherId }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({
+        ...$validChildRow,
+        teacherId,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('invalid_type');
+      expect(result.error!.issues[0].path).toEqual(['teacherId']);
     });
   });
 
   describe('group validation', () => {
-    it.prop({ school: nonEmptyString, _class: nonEmptyString })(
+    it.prop({ school: $nonEmptyString, _class: $nonEmptyString })(
       'accepts a row with exactly one school and one class',
       ({ school, _class }) => {
         expect(() =>
           ChildUserCsvRow.parse({
-            ...validChildRow,
+            ...$validChildRow,
             school,
             class: _class,
             cohort: '',
@@ -475,12 +715,12 @@ describe('ChildUserCsvRow', () => {
       },
     );
 
-    it.prop({ cohort: nonEmptyString })(
+    it.prop({ cohort: $nonEmptyString })(
       'accepts a row with exactly one cohort',
       ({ cohort }) => {
         expect(() =>
           ChildUserCsvRow.parse({
-            ...validChildRow,
+            ...$validChildRow,
             school: '',
             class: '',
             cohort,
@@ -490,44 +730,50 @@ describe('ChildUserCsvRow', () => {
     );
 
     it.prop({
-      schools: fc.array(nonEmptyString, { minLength: 2 }),
-      _class: nonEmptyString,
+      schools: fc.array($nonEmptyString, { minLength: 2 }),
+      _class: $nonEmptyString,
     })('rejects rows w/ multiple schools', ({ schools, _class }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({
-          ...validChildRow,
-          school: schools.join(','),
-          class: _class,
-          cohort: '',
-        }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({
+        ...$validChildRow,
+        school: schools.join(','),
+        class: _class,
+        cohort: '',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('custom');
+      expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
     });
 
     it.prop({
-      school: nonEmptyString,
-      classes: fc.array(nonEmptyString, { minLength: 2 }),
+      school: $nonEmptyString,
+      classes: fc.array($nonEmptyString, { minLength: 2 }),
     })('rejects rows w/ multiple classes', ({ school, classes }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({
-          ...validChildRow,
-          school,
-          class: classes.join(','),
-          cohort: '',
-        }),
-      ).toThrow();
+      const result = ChildUserCsvRow.safeParse({
+        ...$validChildRow,
+        school,
+        class: classes.join(','),
+        cohort: '',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(1);
+      expect(result.error!.issues[0].code).toEqual('custom');
+      expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
     });
 
-    it.prop({ cohorts: fc.array(nonEmptyString, { minLength: 2 }) })(
+    it.prop({ cohorts: fc.array($nonEmptyString, { minLength: 2 }) })(
       'rejects a row with multiple cohorts',
       ({ cohorts }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({
-            ...validChildRow,
-            school: '',
-            class: '',
-            cohort: cohorts.join(','),
-          }),
-        ).toThrow();
+        const result = ChildUserCsvRow.safeParse({
+          ...$validChildRow,
+          school: '',
+          class: '',
+          cohort: cohorts.join(','),
+        });
+        expect(result.success).toBe(false);
+        expect(result.error!.issues.length).toBe(1);
+        expect(result.error!.issues[0].code).toEqual('custom');
+        expect(result.error!.issues[0].path).toEqual(['school|class|cohort']);
       },
     );
   });
@@ -536,7 +782,7 @@ describe('ChildUserCsvRow', () => {
 describe('TeacherUserCsvRow', () => {
   it('accepts a valid row', () => {
     expect(() =>
-      TeacherUserCsvRow.parse({ ...validAdultRow, userType: 'teacher' }),
+      TeacherUserCsvRow.parse({ ...$validAdultRow, userType: 'teacher' }),
     ).not.toThrow();
   });
 });
@@ -545,16 +791,226 @@ describe('UserCsvSchema', () => {
   it('accepts valid rows', () => {
     expect(() =>
       UserCsvSchema.parse([
-        { ...validChildRow },
-        { ...validAdultRow, userType: 'caregiver' },
-        { ...validAdultRow, userType: 'teacher' },
+        { ...$validChildRow, id: 'user-1' },
+        { ...$validAdultRow, id: 'user-2', userType: 'caregiver' },
+        { ...$validAdultRow, id: 'user-3', userType: 'teacher' },
       ]),
     ).not.toThrow();
   });
 
   it('rejects a row with undefined userType', () => {
-    expect(() =>
-      UserCsvSchema.parse([{ ...validChildRow, userType: undefined }]),
-    ).toThrow();
+    const result = UserCsvSchema.safeParse([
+      { ...$validChildRow, userType: undefined },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.length).toBe(1);
+    expect(result.error!.issues[0].code).toEqual('invalid_union');
+    expect(result.error!.issues[0].message).toEqual(
+      'Must be caregiver, child, or teacher',
+    );
+    expect(result.error!.issues[0].path).toEqual([0, 'userType']);
+  });
+
+  describe('unique id validation', () => {
+    it('rejects rows w/ a duplicated id', () => {
+      const result = UserCsvSchema.safeParse([
+        { ...$validChildRow, id: 'dup' },
+        { ...$validChildRow, id: 'unique' },
+        { ...$validChildRow, id: 'dup' },
+      ]);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(2);
+      result.error!.issues.forEach((issue) => {
+        expect(issue.code).toEqual('custom');
+        expect(issue.message).toEqual('Must be unique');
+      });
+      expect(result.error!.issues.map((i) => i.path)).toEqual([
+        [0, 'id'],
+        [2, 'id'],
+      ]);
+    });
+
+    it('flags every row participating in a duplicate', () => {
+      const result = UserCsvSchema.safeParse([
+        { ...$validChildRow, id: 'dup' },
+        { ...$validChildRow, id: 'dup' },
+        { ...$validChildRow, id: 'dup' },
+      ]);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.map((i) => i.path)).toEqual([
+        [0, 'id'],
+        [1, 'id'],
+        [2, 'id'],
+      ]);
+    });
+
+    it('treats ids as unique after trimming', () => {
+      const result = UserCsvSchema.safeParse([
+        { ...$validChildRow, id: 'user-1' },
+        { ...$validChildRow, id: '  user-1  ' },
+      ]);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(2);
+      expect(result.error!.issues.map((i) => i.path)).toEqual([
+        [0, 'id'],
+        [1, 'id'],
+      ]);
+    });
+
+    it('reports each duplicate group separately', () => {
+      const result = UserCsvSchema.safeParse([
+        { ...$validChildRow, id: 'a' },
+        { ...$validChildRow, id: 'b' },
+        { ...$validChildRow, id: 'a' },
+        { ...$validChildRow, id: 'b' },
+      ]);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues.length).toBe(4);
+      expect(result.error!.issues.map((i) => i.path)).toEqual([
+        [0, 'id'],
+        [2, 'id'],
+        [1, 'id'],
+        [3, 'id'],
+      ]);
+    });
+  });
+});
+
+describe('combineUserCsvIssues', () => {
+  it('returns an empty array for no issues', () => {
+    expect(combineUserCsvIssues([])).toEqual([]);
+  });
+
+  it('formats a single row-scoped issue as "path: message"', () => {
+    const result = combineUserCsvIssues([$makeIssue([0, 'id'], 'Required')]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2] }]);
+  });
+
+  it('offsets rowNum by +2 (header row + 1-indexing)', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'id'], 'Required'),
+      $makeIssue([5, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2, 7] }]);
+  });
+
+  it('joins multi-segment paths with "."', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'nested', 'field'], 'Invalid'),
+    ]);
+    expect(result).toEqual([
+      { message: 'nested.field: Invalid', rowNums: [2] },
+    ]);
+  });
+
+  it('combines issues w/ the same message across multiple rows', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'id'], 'Required'),
+      $makeIssue([1, 'id'], 'Required'),
+      $makeIssue([2, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2, 3, 4] }]);
+  });
+
+  it('deduplicates rowNums when the same row has duplicate messages', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'id'], 'Required'),
+      $makeIssue([0, 'id'], 'Required'),
+      $makeIssue([1, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2, 3] }]);
+  });
+
+  it('sorts rowNums ascending regardless of issue order', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([7, 'id'], 'Required'),
+      $makeIssue([1, 'id'], 'Required'),
+      $makeIssue([3, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [3, 5, 9] }]);
+  });
+
+  it('separates issues w/ different messages into distinct entries', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'id'], 'Required'),
+      $makeIssue([0, 'year'], 'Must be a number'),
+    ]);
+    expect(result).toEqual([
+      { message: 'id: Required', rowNums: [2] },
+      { message: 'year: Must be a number', rowNums: [2] },
+    ]);
+  });
+
+  it('separates issues w/ same field but different messages', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'year'], 'Must be >=1000'),
+      $makeIssue([1, 'year'], 'Must be <=9999'),
+    ]);
+    expect(result).toEqual([
+      { message: 'year: Must be >=1000', rowNums: [2] },
+      { message: 'year: Must be <=9999', rowNums: [3] },
+    ]);
+  });
+
+  it('preserves order of first occurrence across messages', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([0, 'year'], 'Must be >=1000'),
+      $makeIssue([1, 'id'], 'Required'),
+      $makeIssue([2, 'year'], 'Must be >=1000'),
+    ]);
+    expect(result).toEqual([
+      { message: 'year: Must be >=1000', rowNums: [2, 4] },
+      { message: 'id: Required', rowNums: [3] },
+    ]);
+  });
+
+  it('filters out issues w/ empty path', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue([], 'Root-level error'),
+      $makeIssue([0, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2] }]);
+  });
+
+  it('skips issues whose first path segment is not a number', () => {
+    const result = combineUserCsvIssues([
+      $makeIssue(['notARow', 'id'], 'Required'),
+      $makeIssue([0, 'id'], 'Required'),
+    ]);
+    expect(result).toEqual([{ message: 'id: Required', rowNums: [2] }]);
+  });
+
+  it('defaults missing issue.message to "Invalid"', () => {
+    const result = combineUserCsvIssues([$makeIssue([0, 'id'], undefined)]);
+    expect(result).toEqual([{ message: 'id: Invalid', rowNums: [2] }]);
+  });
+
+  it('handles issues w/ only a row number (no field path)', () => {
+    const result = combineUserCsvIssues([$makeIssue([0], 'Something broke')]);
+    expect(result).toEqual([{ message: ': Something broke', rowNums: [2] }]);
+  });
+
+  it('combines issues produced by UserCsvSchema for real validation errors', () => {
+    const parseResult = UserCsvSchema.safeParse([
+      { ...$validChildRow, id: '' }, // row 0: id required
+      { ...$validChildRow, id: '' }, // row 1: id required (same message)
+      {
+        ...$validAdultRow,
+        userType: 'caregiver',
+        school: '',
+        class: '',
+        cohort: '',
+      }, // row 2: missing group
+    ]);
+    expect(parseResult.success).toBe(false);
+    const combined = combineUserCsvIssues(parseResult.error!.issues);
+    expect(combined).toEqual([
+      { message: 'id: Required', rowNums: [2, 3] },
+      {
+        message:
+          'school|class|cohort: Must have either school and class OR cohort',
+        rowNums: [4],
+      },
+    ]);
   });
 });

--- a/tests/user-csv.test.ts
+++ b/tests/user-csv.test.ts
@@ -1,0 +1,521 @@
+import { fc, it } from '@fast-check/vitest';
+import { describe, expect } from 'vitest';
+import {
+  CaregiverUserCsvRow,
+  ChildUserCsvRow,
+  ListableString,
+  TeacherUserCsvRow,
+  UserCsv,
+  UserCsvRowBase,
+} from '../src/user-csv';
+
+/** Arbitrary: a non-empty string (NB: trim-stable and comma-free so it
+ *  produces exactly one ListableString part) */
+const nonEmptyString = fc
+  .string({ minLength: 1 })
+  .filter((s) => s.trim() === s && !s.includes(','));
+
+/** Arbitrary: a non-empty array of non-empty strings */
+const nonEmptyStringArray = fc.array(nonEmptyString, { minLength: 1 });
+
+/** Arbitrary: a non-string value */
+const nonString = fc.anything().filter((v) => typeof v !== 'string');
+
+/** Arbitrary: a non-number value */
+const nonNumber = fc.anything().filter((v) => typeof v !== 'number');
+
+/** Arbitrary: a non-integer number value */
+const nonIntegerNumber = fc.float().filter((n) => !Number.isInteger(n));
+
+/** Fixture: a valid caregiver/teacher row to derive test fixtures from */
+const validAdultRow = {
+  id: 'user-1',
+  userType: undefined, // NB: must be defined by the test case
+  month: undefined,
+  year: undefined,
+  caregiverId: undefined,
+  teacherId: undefined,
+  site: 'site-1',
+  school: 'school-1',
+  class: 'class-1',
+  cohort: undefined,
+};
+
+/** Fixture: a valid child row to derive test fixtures from */
+const validChildRow = {
+  id: 'user-1',
+  userType: 'child',
+  month: 1,
+  year: 2020,
+  caregiverId: 'caregiver-1',
+  teacherId: 'teacher-1',
+  site: 'site-1',
+  school: 'school-1',
+  class: 'class-1',
+  cohort: undefined,
+};
+
+describe('ListableString', () => {
+  it.prop({
+    parts: nonEmptyStringArray,
+  })('parses comma-separated string into an array', ({ parts }) => {
+    expect(ListableString.parse(parts.join(','))).toEqual(parts);
+  });
+
+  it.prop({
+    parts: nonEmptyStringArray,
+  })('trims whitespace from each part', ({ parts }) => {
+    expect(ListableString.parse(parts.join(' , '))).toEqual(parts);
+  });
+
+  it.prop({
+    parts: nonEmptyStringArray,
+  })('filters out empty parts', ({ parts }) => {
+    expect(ListableString.parse(parts.join(', ,,'))).toEqual(parts);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(ListableString.parse('')).toEqual([]);
+  });
+
+  it.prop({ v: nonString })('rejects any non-string input', ({ v }) => {
+    expect(() => ListableString.parse(v)).toThrow();
+  });
+});
+
+describe('UserCsvRowBase', () => {
+  it('accepts a valid row', () => {
+    expect(() => UserCsvRowBase.parse(validChildRow)).not.toThrow();
+  });
+
+  it('keeps loose properties', () => {
+    const result = UserCsvRowBase.safeParse({
+      ...validChildRow,
+      unexpected: 'value',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.unexpected).toEqual('value');
+  });
+
+  describe('id validation', () => {
+    it.prop({ id: nonEmptyString })('accepts non-empty strings', ({ id }) => {
+      expect(() =>
+        UserCsvRowBase.parse({ ...validChildRow, id }),
+      ).not.toThrow();
+    });
+
+    it.prop({ id: nonEmptyString })('trims whitespace', ({ id }) => {
+      const result = UserCsvRowBase.safeParse({
+        ...validChildRow,
+        id: ` ${id}  `,
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.id).toBe(id);
+    });
+
+    it('rejects an empty string', () => {
+      expect(() =>
+        UserCsvRowBase.parse({ ...validChildRow, id: '' }),
+      ).toThrow();
+    });
+
+    it('rejects a whitespace-only string', () => {
+      expect(() =>
+        UserCsvRowBase.parse({ ...validChildRow, id: '   ' }),
+      ).toThrow();
+    });
+
+    it.prop({ id: nonString })('rejects non-strings', ({ id }) => {
+      expect(() => UserCsvRowBase.parse({ ...validChildRow, id })).toThrow();
+    });
+  });
+
+  describe('group validation (valid combinations)', () => {
+    it.prop({
+      school: nonEmptyString,
+      _class: nonEmptyString, // NB: underscore avoids conflict w/ class property
+    })('accepts rows w/ school+class (no cohort)', ({ school, _class }) => {
+      expect(() =>
+        UserCsvRowBase.parse({
+          ...validChildRow,
+          school,
+          class: _class,
+          cohort: undefined,
+        }),
+      ).not.toThrow();
+    });
+
+    it.prop({
+      schools: nonEmptyStringArray,
+      classes: nonEmptyStringArray,
+    })(
+      'accepts rows w/ schools+classes (no cohort)',
+      ({ schools, classes }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school: schools.join(','),
+            class: classes.join(','),
+            cohort: undefined,
+          }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({ cohort: nonEmptyString })(
+      'accepts rows w/ cohort (no school+class)',
+      ({ cohort }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school: undefined,
+            class: undefined,
+            cohort,
+          }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({ cohorts: nonEmptyStringArray })(
+      'accepts rows w/ cohorts (no school+class)',
+      ({ cohorts }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school: undefined,
+            class: undefined,
+            cohort: cohorts.join(','),
+          }),
+        ).not.toThrow();
+      },
+    );
+  });
+
+  describe('group validation (invalid combinations)', () => {
+    it('rejects a row w/ no group', () => {
+      expect(() =>
+        UserCsvRowBase.parse({
+          ...validChildRow,
+          school: undefined,
+          class: undefined,
+          cohort: undefined,
+        }),
+      ).toThrow();
+    });
+
+    it.prop({ school: nonEmptyString })(
+      'rejects rows w/ school but no class',
+      ({ school }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school,
+            class: undefined,
+            cohort: undefined,
+          }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ _class: nonEmptyString })(
+      'rejects rows w/ class but no school',
+      ({ _class }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school: undefined,
+            class: _class,
+            cohort: undefined,
+          }),
+        ).toThrow();
+      },
+    );
+
+    it('rejects a row w/ empty string group', () => {
+      expect(() =>
+        UserCsvRowBase.parse({
+          ...validChildRow,
+          school: '',
+          class: '',
+          cohort: '',
+        }),
+      ).toThrow();
+    });
+
+    it.prop({
+      school: nonEmptyString,
+      _class: nonEmptyString,
+      cohort: nonEmptyString,
+    })(
+      'rejects rows w/ both school+class and cohort',
+      ({ school, _class, cohort }) => {
+        expect(() =>
+          UserCsvRowBase.parse({
+            ...validChildRow,
+            school,
+            class: _class,
+            cohort,
+          }),
+        ).toThrow();
+      },
+    );
+  });
+});
+
+describe('CaregiverUserCsvRow', () => {
+  it('accepts a valid row', () => {
+    expect(() =>
+      CaregiverUserCsvRow.parse({ ...validAdultRow, userType: 'caregiver' }),
+    ).not.toThrow();
+  });
+
+  it('keeps loose properties', () => {
+    const result = CaregiverUserCsvRow.safeParse({
+      ...validAdultRow,
+      userType: 'caregiver',
+      unexpected: 'value',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.unexpected).toEqual('value');
+  });
+});
+
+describe('ChildUserCsvRow', () => {
+  it('accepts a valid row', () => {
+    expect(() => ChildUserCsvRow.parse({ ...validChildRow })).not.toThrow();
+  });
+
+  describe('month validation', () => {
+    it.prop({ month: fc.integer({ min: 1, max: 12 }) })(
+      'accepts valid months (1-12)',
+      ({ month }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, month }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({ month: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 0 }) })(
+      'rejects months below 1',
+      ({ month }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, month }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ month: fc.integer({ min: 13, max: Number.MAX_SAFE_INTEGER }) })(
+      'rejects months above 12',
+      ({ month }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, month }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ month: nonIntegerNumber })(
+      'rejects non-integer numbers',
+      ({ month }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, month }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ month: nonNumber })('rejects non-numbers', ({ month }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, month }),
+      ).toThrow();
+    });
+  });
+
+  describe('year validation', () => {
+    it.prop({ year: fc.integer({ min: 1000, max: 9999 }) })(
+      'accepts valid years (1000-9999)',
+      ({ year }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, year }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({ year: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 999 }) })(
+      'rejects years below 1000',
+      ({ year }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, year }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ year: fc.integer({ min: 10000, max: Number.MAX_SAFE_INTEGER }) })(
+      'rejects years above 9999',
+      ({ year }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, year }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ year: nonIntegerNumber })(
+      'rejects non-integer numbers',
+      ({ year }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, year }),
+        ).toThrow();
+      },
+    );
+
+    it.prop({ year: nonNumber })('rejects non-numbers', ({ year }) => {
+      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
+    });
+  });
+
+  describe('caregiverId validation', () => {
+    it('accepts undefined caregiverId', () => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, caregiverId: undefined }),
+      ).not.toThrow();
+    });
+
+    it.prop({ parts: nonEmptyStringArray })(
+      'accepts a comma-separated string and parses it into an array',
+      ({ parts }) => {
+        const result = ChildUserCsvRow.safeParse({
+          ...validChildRow,
+          caregiverId: parts.join(','),
+        });
+        expect(result.success).toBe(true);
+        expect(result.data?.caregiverId).toEqual(parts);
+      },
+    );
+
+    it.prop({
+      caregiverId: nonString.filter((v) => v !== undefined),
+    })('rejects non-string, non-undefined values', ({ caregiverId }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, caregiverId }),
+      ).toThrow();
+    });
+  });
+
+  describe('teacherId validation', () => {
+    it('accepts undefined teacherId', () => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, teacherId: undefined }),
+      ).not.toThrow();
+    });
+
+    it.prop({ parts: nonEmptyStringArray })(
+      'accepts a comma-separated string and parses it into an array',
+      ({ parts }) => {
+        const result = ChildUserCsvRow.safeParse({
+          ...validChildRow,
+          teacherId: parts.join(','),
+        });
+        expect(result.success).toBe(true);
+        expect(result.data?.teacherId).toEqual(parts);
+      },
+    );
+
+    it.prop({
+      teacherId: nonString.filter((v) => v !== undefined),
+    })('rejects non-string, non-undefined values', ({ teacherId }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, teacherId }),
+      ).toThrow();
+    });
+  });
+
+  describe('group validation', () => {
+    it.prop({ school: nonEmptyString, _class: nonEmptyString })(
+      'accepts a row with exactly one school and one class',
+      ({ school, _class }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({
+            ...validChildRow,
+            school,
+            class: _class,
+            cohort: undefined,
+          }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({ cohort: nonEmptyString })(
+      'accepts a row with exactly one cohort',
+      ({ cohort }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({
+            ...validChildRow,
+            school: undefined,
+            class: undefined,
+            cohort,
+          }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({
+      schools: fc.array(nonEmptyString, { minLength: 2 }),
+      _class: nonEmptyString,
+    })('rejects rows w/ multiple schools', ({ schools, _class }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({
+          ...validChildRow,
+          school: schools.join(','),
+          class: _class,
+          cohort: undefined,
+        }),
+      ).toThrow();
+    });
+
+    it.prop({
+      school: nonEmptyString,
+      classes: fc.array(nonEmptyString, { minLength: 2 }),
+    })('rejects rows w/ multiple classes', ({ school, classes }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({
+          ...validChildRow,
+          school,
+          class: classes.join(','),
+          cohort: undefined,
+        }),
+      ).toThrow();
+    });
+
+    it.prop({ cohorts: fc.array(nonEmptyString, { minLength: 2 }) })(
+      'rejects a row with multiple cohorts',
+      ({ cohorts }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({
+            ...validChildRow,
+            school: undefined,
+            class: undefined,
+            cohort: cohorts.join(','),
+          }),
+        ).toThrow();
+      },
+    );
+  });
+});
+
+describe('TeacherUserCsvRow', () => {
+  it('accepts a valid row', () => {
+    expect(() =>
+      TeacherUserCsvRow.parse({ ...validAdultRow, userType: 'teacher' }),
+    ).not.toThrow();
+  });
+});
+
+describe('UserCsv', () => {
+  it('accepts valid rows', () => {
+    expect(() =>
+      UserCsv.parse([
+        { ...validChildRow },
+        { ...validAdultRow, userType: 'caregiver' },
+        { ...validAdultRow, userType: 'teacher' },
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/tests/user-csv.test.ts
+++ b/tests/user-csv.test.ts
@@ -4,9 +4,10 @@ import {
   CaregiverUserCsvRow,
   ChildUserCsvRow,
   ListableString,
+  NumberString,
   TeacherUserCsvRow,
-  UserCsv,
   UserCsvRowBase,
+  UserCsvSchema,
 } from '../src/user-csv';
 
 /** Arbitrary: a non-empty string (NB: trim-stable and comma-free so it
@@ -18,41 +19,47 @@ const nonEmptyString = fc
 /** Arbitrary: a non-empty array of non-empty strings */
 const nonEmptyStringArray = fc.array(nonEmptyString, { minLength: 1 });
 
+/** Arbitrary: a non-integer number value */
+const nonIntegerNumber = fc
+  .float()
+  .filter((n) => !Number.isInteger(n))
+  .map(String);
+
+/** Arbitrary: a non-number string (e.g., "foo", "one") */
+const nonNumberString = fc.string().filter((v) => Number.isNaN(Number(v)));
+
 /** Arbitrary: a non-string value */
 const nonString = fc.anything().filter((v) => typeof v !== 'string');
 
-/** Arbitrary: a non-number value */
-const nonNumber = fc.anything().filter((v) => typeof v !== 'number');
-
-/** Arbitrary: a non-integer number value */
-const nonIntegerNumber = fc.float().filter((n) => !Number.isInteger(n));
+/** Arbitrary: a number string (e.g., "123", "123.456", "NaN") */
+const numberString = fc
+  .oneof(fc.float(), fc.integer(), fc.constant('NaN'))
+  .map(String);
 
 /** Fixture: a valid caregiver/teacher row to derive test fixtures from */
 const validAdultRow = {
   id: 'user-1',
   userType: undefined, // NB: must be defined by the test case
-  month: undefined,
-  year: undefined,
-  caregiverId: undefined,
-  teacherId: undefined,
-  site: 'site-1',
+  month: '',
+  year: '',
+  caregiverId: '',
+  teacherId: '',
   school: 'school-1',
   class: 'class-1',
-  cohort: undefined,
+  cohort: '',
 };
 
 /** Fixture: a valid child row to derive test fixtures from */
 const validChildRow = {
   id: 'user-1',
   userType: 'child',
-  month: 1,
-  year: 2020,
+  month: '1',
+  year: '2020',
   caregiverId: 'caregiver-1',
   teacherId: 'teacher-1',
-  site: 'site-1',
   school: 'school-1',
   class: 'class-1',
-  cohort: undefined,
+  cohort: '',
 };
 
 describe('ListableString', () => {
@@ -78,8 +85,25 @@ describe('ListableString', () => {
     expect(ListableString.parse('')).toEqual([]);
   });
 
-  it.prop({ v: nonString })('rejects any non-string input', ({ v }) => {
+  it.prop({ v: nonString })('rejects non-strings', ({ v }) => {
     expect(() => ListableString.parse(v)).toThrow();
+  });
+});
+
+describe('NumberString', () => {
+  it.prop({ v: numberString })('coerces strings into numbers', ({ v }) => {
+    expect(NumberString.parse(v)).toEqual(Number(v));
+  });
+
+  it.prop({ v: nonNumberString })(
+    'coerces non-number strings into NaN',
+    ({ v }) => {
+      expect(NumberString.parse(v)).toBeNaN();
+    },
+  );
+
+  it.prop({ v: nonString })('rejects non-strings', ({ v }) => {
+    expect(() => NumberString.parse(v)).toThrow();
   });
 });
 
@@ -91,10 +115,10 @@ describe('UserCsvRowBase', () => {
   it('keeps loose properties', () => {
     const result = UserCsvRowBase.safeParse({
       ...validChildRow,
-      unexpected: 'value',
+      site: 'site-1',
     });
     expect(result.success).toBe(true);
-    expect(result.data?.unexpected).toEqual('value');
+    expect(result.data?.site).toEqual('site-1');
   });
 
   describe('id validation', () => {
@@ -140,7 +164,7 @@ describe('UserCsvRowBase', () => {
           ...validChildRow,
           school,
           class: _class,
-          cohort: undefined,
+          cohort: '',
         }),
       ).not.toThrow();
     });
@@ -156,7 +180,7 @@ describe('UserCsvRowBase', () => {
             ...validChildRow,
             school: schools.join(','),
             class: classes.join(','),
-            cohort: undefined,
+            cohort: '',
           }),
         ).not.toThrow();
       },
@@ -168,8 +192,8 @@ describe('UserCsvRowBase', () => {
         expect(() =>
           UserCsvRowBase.parse({
             ...validChildRow,
-            school: undefined,
-            class: undefined,
+            school: '',
+            class: '',
             cohort,
           }),
         ).not.toThrow();
@@ -182,8 +206,8 @@ describe('UserCsvRowBase', () => {
         expect(() =>
           UserCsvRowBase.parse({
             ...validChildRow,
-            school: undefined,
-            class: undefined,
+            school: '',
+            class: '',
             cohort: cohorts.join(','),
           }),
         ).not.toThrow();
@@ -196,9 +220,9 @@ describe('UserCsvRowBase', () => {
       expect(() =>
         UserCsvRowBase.parse({
           ...validChildRow,
-          school: undefined,
-          class: undefined,
-          cohort: undefined,
+          school: '',
+          class: '',
+          cohort: '',
         }),
       ).toThrow();
     });
@@ -210,8 +234,8 @@ describe('UserCsvRowBase', () => {
           UserCsvRowBase.parse({
             ...validChildRow,
             school,
-            class: undefined,
-            cohort: undefined,
+            class: '',
+            cohort: '',
           }),
         ).toThrow();
       },
@@ -223,24 +247,13 @@ describe('UserCsvRowBase', () => {
         expect(() =>
           UserCsvRowBase.parse({
             ...validChildRow,
-            school: undefined,
+            school: '',
             class: _class,
-            cohort: undefined,
+            cohort: '',
           }),
         ).toThrow();
       },
     );
-
-    it('rejects a row w/ empty string group', () => {
-      expect(() =>
-        UserCsvRowBase.parse({
-          ...validChildRow,
-          school: '',
-          class: '',
-          cohort: '',
-        }),
-      ).toThrow();
-    });
 
     it.prop({
       school: nonEmptyString,
@@ -273,10 +286,22 @@ describe('CaregiverUserCsvRow', () => {
     const result = CaregiverUserCsvRow.safeParse({
       ...validAdultRow,
       userType: 'caregiver',
-      unexpected: 'value',
+      site: 'site-1',
     });
     expect(result.success).toBe(true);
-    expect(result.data?.unexpected).toEqual('value');
+    expect(result.data?.site).toEqual('site-1');
+  });
+
+  it('rejects rows missing expected fields', () => {
+    ['id', 'userType', 'school', 'class', 'cohort'].forEach((key) => {
+      expect(() =>
+        CaregiverUserCsvRow.parse({
+          ...validAdultRow,
+          userType: 'caregiver',
+          [key]: undefined,
+        }),
+      ).toThrow();
+    });
   });
 });
 
@@ -286,7 +311,7 @@ describe('ChildUserCsvRow', () => {
   });
 
   describe('month validation', () => {
-    it.prop({ month: fc.integer({ min: 1, max: 12 }) })(
+    it.prop({ month: fc.integer({ min: 1, max: 12 }).map(String) })(
       'accepts valid months (1-12)',
       ({ month }) => {
         expect(() =>
@@ -295,23 +320,27 @@ describe('ChildUserCsvRow', () => {
       },
     );
 
-    it.prop({ month: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 0 }) })(
-      'rejects months below 1',
-      ({ month }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, month }),
-        ).toThrow();
-      },
-    );
+    it.prop({
+      month: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 0 }).map(String),
+    })('rejects months below 1', ({ month }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, month }),
+      ).toThrow();
+    });
 
-    it.prop({ month: fc.integer({ min: 13, max: Number.MAX_SAFE_INTEGER }) })(
-      'rejects months above 12',
-      ({ month }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, month }),
-        ).toThrow();
-      },
-    );
+    it.prop({
+      month: fc.integer({ min: 13, max: Number.MAX_SAFE_INTEGER }).map(String),
+    })('rejects months above 12', ({ month }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, month }),
+      ).toThrow();
+    });
+
+    it.prop({ month: nonString })('rejects non-strings', ({ month }) => {
+      expect(() =>
+        ChildUserCsvRow.parse({ ...validChildRow, month }),
+      ).toThrow();
+    });
 
     it.prop({ month: nonIntegerNumber })(
       'rejects non-integer numbers',
@@ -322,15 +351,18 @@ describe('ChildUserCsvRow', () => {
       },
     );
 
-    it.prop({ month: nonNumber })('rejects non-numbers', ({ month }) => {
-      expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, month }),
-      ).toThrow();
-    });
+    it.prop({ month: nonNumberString })(
+      'rejects non-number strings',
+      ({ month }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, month }),
+        ).toThrow();
+      },
+    );
   });
 
   describe('year validation', () => {
-    it.prop({ year: fc.integer({ min: 1000, max: 9999 }) })(
+    it.prop({ year: fc.integer({ min: 1000, max: 9999 }).map(String) })(
       'accepts valid years (1000-9999)',
       ({ year }) => {
         expect(() =>
@@ -339,23 +371,19 @@ describe('ChildUserCsvRow', () => {
       },
     );
 
-    it.prop({ year: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 999 }) })(
-      'rejects years below 1000',
-      ({ year }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, year }),
-        ).toThrow();
-      },
-    );
+    it.prop({
+      year: fc.integer({ min: Number.MIN_SAFE_INTEGER, max: 999 }).map(String),
+    })('rejects years below 1000', ({ year }) => {
+      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
+    });
 
-    it.prop({ year: fc.integer({ min: 10000, max: Number.MAX_SAFE_INTEGER }) })(
-      'rejects years above 9999',
-      ({ year }) => {
-        expect(() =>
-          ChildUserCsvRow.parse({ ...validChildRow, year }),
-        ).toThrow();
-      },
-    );
+    it.prop({
+      year: fc
+        .integer({ min: 10000, max: Number.MAX_SAFE_INTEGER })
+        .map(String),
+    })('rejects years above 9999', ({ year }) => {
+      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
+    });
 
     it.prop({ year: nonIntegerNumber })(
       'rejects non-integer numbers',
@@ -366,15 +394,20 @@ describe('ChildUserCsvRow', () => {
       },
     );
 
-    it.prop({ year: nonNumber })('rejects non-numbers', ({ year }) => {
-      expect(() => ChildUserCsvRow.parse({ ...validChildRow, year })).toThrow();
-    });
+    it.prop({ year: nonNumberString })(
+      'rejects non-number strings',
+      ({ year }) => {
+        expect(() =>
+          ChildUserCsvRow.parse({ ...validChildRow, year }),
+        ).toThrow();
+      },
+    );
   });
 
   describe('caregiverId validation', () => {
-    it('accepts undefined caregiverId', () => {
+    it('accepts an empty caregiverId', () => {
       expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, caregiverId: undefined }),
+        ChildUserCsvRow.parse({ ...validChildRow, caregiverId: '' }),
       ).not.toThrow();
     });
 
@@ -391,8 +424,8 @@ describe('ChildUserCsvRow', () => {
     );
 
     it.prop({
-      caregiverId: nonString.filter((v) => v !== undefined),
-    })('rejects non-string, non-undefined values', ({ caregiverId }) => {
+      caregiverId: nonString,
+    })('rejects non-strings', ({ caregiverId }) => {
       expect(() =>
         ChildUserCsvRow.parse({ ...validChildRow, caregiverId }),
       ).toThrow();
@@ -400,9 +433,9 @@ describe('ChildUserCsvRow', () => {
   });
 
   describe('teacherId validation', () => {
-    it('accepts undefined teacherId', () => {
+    it('accepts an empty teacherId', () => {
       expect(() =>
-        ChildUserCsvRow.parse({ ...validChildRow, teacherId: undefined }),
+        ChildUserCsvRow.parse({ ...validChildRow, teacherId: '' }),
       ).not.toThrow();
     });
 
@@ -419,8 +452,8 @@ describe('ChildUserCsvRow', () => {
     );
 
     it.prop({
-      teacherId: nonString.filter((v) => v !== undefined),
-    })('rejects non-string, non-undefined values', ({ teacherId }) => {
+      teacherId: nonString,
+    })('rejects non-strings', ({ teacherId }) => {
       expect(() =>
         ChildUserCsvRow.parse({ ...validChildRow, teacherId }),
       ).toThrow();
@@ -436,7 +469,7 @@ describe('ChildUserCsvRow', () => {
             ...validChildRow,
             school,
             class: _class,
-            cohort: undefined,
+            cohort: '',
           }),
         ).not.toThrow();
       },
@@ -448,8 +481,8 @@ describe('ChildUserCsvRow', () => {
         expect(() =>
           ChildUserCsvRow.parse({
             ...validChildRow,
-            school: undefined,
-            class: undefined,
+            school: '',
+            class: '',
             cohort,
           }),
         ).not.toThrow();
@@ -465,7 +498,7 @@ describe('ChildUserCsvRow', () => {
           ...validChildRow,
           school: schools.join(','),
           class: _class,
-          cohort: undefined,
+          cohort: '',
         }),
       ).toThrow();
     });
@@ -479,7 +512,7 @@ describe('ChildUserCsvRow', () => {
           ...validChildRow,
           school,
           class: classes.join(','),
-          cohort: undefined,
+          cohort: '',
         }),
       ).toThrow();
     });
@@ -490,8 +523,8 @@ describe('ChildUserCsvRow', () => {
         expect(() =>
           ChildUserCsvRow.parse({
             ...validChildRow,
-            school: undefined,
-            class: undefined,
+            school: '',
+            class: '',
             cohort: cohorts.join(','),
           }),
         ).toThrow();
@@ -508,14 +541,20 @@ describe('TeacherUserCsvRow', () => {
   });
 });
 
-describe('UserCsv', () => {
+describe('UserCsvSchema', () => {
   it('accepts valid rows', () => {
     expect(() =>
-      UserCsv.parse([
+      UserCsvSchema.parse([
         { ...validChildRow },
         { ...validAdultRow, userType: 'caregiver' },
         { ...validAdultRow, userType: 'teacher' },
       ]),
     ).not.toThrow();
+  });
+
+  it('rejects a row with undefined userType', () => {
+    expect(() =>
+      UserCsvSchema.parse([{ ...validChildRow, userType: undefined }]),
+    ).toThrow();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./",
@@ -25,5 +25,5 @@
     "allowUnreachableCode": false
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Changelog

- Add library exports w/ respective unit tests:
  - `AddUserCsvHeaderSchema`, `AddUserCsvHeaderType`
  - `combineUserCsvIssues`
  - `UserCsvSchema`, `UserCsvType`
- Deprecate library exports:
  - `normalizeCsvData`, `normalizeCsvHeaders` to be handled upstream
  - `AddUsersCsvSchema`, `AddUsersCsvType`, `combineIssues`, `parseCommaSeparated`, `validateAddUsersCsv`, `validateCsvData`, `validateAddUsersFileUpload` in favor of `combineUserCsvIssues`, `UserCsvSchema`
  - `CsvHeadersSchema`, `CsvHeadersType`, `validateCsvHeaders` in favor of `AddUserCsvHeaderSchema`
- Deprecate library exports for future work:
  - `AddUsersSubmitSchema`, `AddUsersSubmitType`
  - `validateAddUsersSubmit`
  - `LinkUsersCsvSchema`, `LinkUsersCsvType`
  - `validateLinkUsersCsv`
- Move tests to be colocated
- Add dev deps fast-check, @fast-check/vitest for PBT
- Bump GH action deps to v6
- Add CC comments for future design discussions

## Future work not covered here

- Rework `AddUsersSubmitSchema`, `validateAddUsersSubmit`
- Rework `LinkUsersCsvSchema`, `validateLinkUsersCsv`; add `LinkUserCsvHeaderSchema`
  - `UserCsvSchema` only covers the Add Users workflow in this PR, including Link Users may change this interface