### PR TITLE
Fix Publish Action

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,4 +33,3 @@ The Levante Bot GitHub App must:
 |---|---|---|
 | `Use workflow from` | `main` | Must always be `main` |
 | `release-type` | `patch` | One of `patch`, `minor`, or `major` |
-| `dry-run` | `false` | If checked, runs all checks and bumps the version locally but skips pushing, publishing, and creating a release |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,8 +18,14 @@ Manually triggered workflow that:
 
 | Secret | Purpose |
 |---|---|
-| `GITHUB_TOKEN` | Automatically provided by GitHub — used to push the version bump commit and tag, and to create the GitHub Release; requires `contents: write` and `id-token: write` permissions (configured in the workflow) |
+| `LEVANTE_BOT_APP_ID` | App ID of the Levante Bot GitHub App; used with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) to mint an installation token that can push directly to `main` (the default `GITHUB_TOKEN` is blocked by the repository ruleset that requires PRs) |
+| `LEVANTE_BOT_APP_PRIVATE_KEY` | Private key (PEM) for the Levante Bot GitHub App |
 | `LEVANTE_NPM_TOKEN` | npm access token with publish rights for this package |
+
+The Levante Bot GitHub App must:
+
+- Be installed on this repository with `Contents: write` permission
+- Be listed as a bypass actor on any ruleset targeting `main` that requires pull requests, so the version bump commit and tag can be pushed directly
 
 **Inputs**
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,6 @@ on:
           - patch
           - minor
           - major
-      dry-run:
-        description: 'Dry run (skip push and publish)'
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -76,17 +72,14 @@ jobs:
           npm version ${{ inputs.release-type }} --message "chore: release v%s [skip ci]"
 
       - name: Push commit and tag
-        if: ${{ !inputs.dry-run }}
         run: git push --follow-tags
 
       - name: Publish to npm
-        if: ${{ !inputs.dry-run }}
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.LEVANTE_NPM_TOKEN }}
 
       - name: Create GitHub Release
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.LEVANTE_BOT_APP_ID }}
+          client-id: ${{ secrets.LEVANTE_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.LEVANTE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.LEVANTE_BOT_APP_ID }}
+          private-key: ${{ secrets.LEVANTE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Ensure on main
         run: |
@@ -81,7 +88,7 @@ jobs:
       - name: Create GitHub Release
         if: ${{ !inputs.dry-run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           gh release create "v${VERSION}" --generate-notes --title "v${VERSION}"


### PR DESCRIPTION
Branch protection rules on `main` prevent `github-actions[bot]` from pushing the version bump commit if it uses `GITHUB_TOKEN`.

- Changed `publish.yml` to use `LEVANTE_BOT_APP_ID`/`LEVANTE_BOT_APP_PRIVATE_KEY` to mint a short lived auth token to use instead of `GITHUB_TOKEN`
- Changed `publish.yml` to remove dry-run option, not useful enough