### PR TITLE
Fix firebase-functions/get-site-overview result type

### DIFF
--- a/src/firebase-functions/get-site-overview.ts
+++ b/src/firebase-functions/get-site-overview.ts
@@ -15,13 +15,11 @@ export type GetSiteOverviewParams = z.infer<typeof GetSiteOverviewParamsSchema>;
 export type GetSiteOverviewResult = {
   counts: {
     users: {
-      total: number;
       teachers: number;
       caregivers: number;
       children: number;
     };
     assignments: {
-      total: number;
       open: number;
       upcoming: number;
       closed: number;


### PR DESCRIPTION
- Change `GetSiteOverviewResult` to remove `total` props

The server should only be responsible for complex aggregations/calculations - simple addition can be handled by the client.

This is also consistent w/ the previous decision to make the client responsible for `schools.length + classes.length + cohorts.length` instead of passing a pre-computed `groups.total`.