### PR TITLE
Add Users backend

### DIFF
--- a/src/firebase-functions/create-users.test.ts
+++ b/src/firebase-functions/create-users.test.ts
@@ -1,0 +1,714 @@
+import { fc, it } from '@fast-check/vitest';
+import { describe, expect } from 'vitest';
+import type * as z from 'zod';
+import { CHILD_YEAR_MAX, CHILD_YEAR_MIN } from '../csv/user-csv';
+import {
+  CaregiverUserSchema,
+  ChildUserSchema,
+  CreateUsersParamsSchema,
+  TeacherUserSchema,
+  UserBaseSchema,
+  UserSchema,
+} from './create-users';
+
+/** Arbitrary: a non-array value */
+const $nonArray = fc.anything().filter((v) => !Array.isArray(v));
+
+/** Arbitrary: a non-object value */
+const $nonObject = fc.anything().filter((v) => typeof v !== 'object');
+
+/** Arbitrary: a non-string value */
+const $nonString = fc.anything().filter((v) => typeof v !== 'string');
+
+/** Fixture: a valid user base */
+const $validBase = {
+  id: 'u1',
+  orgIds: { schools: ['s1'], classes: ['c1'], cohorts: [] },
+};
+
+/** Fixture: a valid child user */
+const $validChild = {
+  id: 'u1',
+  userType: 'child' as const,
+  month: 6,
+  year: CHILD_YEAR_MIN + 1,
+  orgIds: { schools: ['s1'], classes: ['c1'], cohorts: [] },
+};
+
+/** Fixture: a valid caregiver user */
+const $validCaregiver = {
+  id: 'u2',
+  userType: 'caregiver' as const,
+  orgIds: { schools: ['s1'], classes: ['c1'], cohorts: [] },
+};
+
+/** Fixture: a valid teacher user */
+const $validTeacher = {
+  id: 'u3',
+  userType: 'teacher' as const,
+  orgIds: { schools: [], classes: [], cohorts: ['co1'] },
+};
+
+/** Fixture: a valid params */
+const $validParams = {
+  siteId: 's1',
+  users: [$validChild, $validCaregiver, $validTeacher],
+};
+
+describe('UserBaseSchema', () => {
+  describe('valid', () => {
+    it('accepts valid props w/ school+class (no cohort)', () => {
+      expect(() => UserBaseSchema.parse($validBase)).not.toThrow();
+    });
+
+    it('accepts valid props w/ cohort (no school+class)', () => {
+      expect(() =>
+        UserBaseSchema.parse({
+          ...$validBase,
+          orgIds: { schools: [], classes: [], cohorts: ['co1'] },
+        }),
+      ).not.toThrow();
+    });
+
+    it('strips unexpected props', () => {
+      const result = UserBaseSchema.safeParse({
+        ...$validBase,
+        unexpected: 'foo',
+      });
+      expect(result.data).toEqual({ ...$validBase });
+    });
+  });
+
+  describe('invalid root', () => {
+    it.prop({ nonObject: $nonObject })(
+      'rejects non-object root',
+      ({ nonObject }) => {
+        const result = UserBaseSchema.safeParse(nonObject);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('object');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected object, received/,
+        );
+        expect(issue.path).toEqual([]);
+      },
+    );
+
+    it('rejects missing props', () => {
+      const result = UserBaseSchema.safeParse({});
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(2);
+      const issues = result.error?.issues as z.core.$ZodIssueInvalidType[];
+      for (const [idx, [expected, path]] of [
+        ['string', 'id'],
+        ['object', 'orgIds'],
+      ].entries()) {
+        const issue = issues[idx];
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual(expected);
+        expect(issue.message).toMatch(
+          new RegExp(`^Invalid input: expected ${expected}, received`),
+        );
+        expect(issue.path).toEqual([path]);
+      }
+    });
+  });
+
+  describe('invalid id', () => {
+    it.prop({ id: $nonString })('rejects non-string id', ({ id }) => {
+      const result = UserBaseSchema.safeParse({ ...$validBase, id });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('string');
+      expect(issue.message).toMatch(
+        /^Invalid input: expected string, received/,
+      );
+      expect(issue.path).toEqual(['id']);
+    });
+
+    it.prop({ id: fc.constantFrom('', '   ') })(
+      'rejects empty or whitespace-only id',
+      ({ id }) => {
+        const result = UserBaseSchema.safeParse({ ...$validBase, id });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        expect(result.error?.issues[0]).toMatchObject({
+          code: 'too_small',
+          path: ['id'],
+        });
+      },
+    );
+  });
+
+  describe('invalid orgIds', () => {
+    it.prop({ orgIds: $nonObject })(
+      'rejects non-object orgIds',
+      ({ orgIds }) => {
+        const result = UserBaseSchema.safeParse({
+          ...$validBase,
+          orgIds,
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('object');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected object, received/,
+        );
+        expect(issue.path).toEqual(['orgIds']);
+      },
+    );
+
+    it.prop({ schools: $nonArray, classes: $nonArray, cohorts: $nonArray })(
+      'rejects non-array orgIds.schools, orgIds.classes, orgIds.cohorts',
+      ({ schools, classes, cohorts }) => {
+        const result = UserBaseSchema.safeParse({
+          ...$validBase,
+          orgIds: {
+            schools,
+            classes,
+            cohorts,
+          },
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(3);
+        const paths = ['schools', 'classes', 'cohorts'];
+        for (let i = 0; i < 3; i++) {
+          const issue = result.error?.issues[i] as z.core.$ZodIssueInvalidType;
+          expect(issue.code).toEqual('invalid_type');
+          expect(issue.expected).toEqual('array');
+          expect(issue.message).toMatch(
+            /^Invalid input: expected array, received/,
+          );
+          expect(issue.path).toEqual(['orgIds', paths[i]]);
+        }
+      },
+    );
+
+    it.prop({ nonString: $nonString })(
+      'rejects non-strings in orgIds.schools, orgIds.classes, orgIds.cohorts',
+      ({ nonString }) => {
+        const result = UserBaseSchema.safeParse({
+          ...$validBase,
+          orgIds: {
+            schools: [nonString],
+            classes: [nonString],
+            cohorts: [nonString],
+          },
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(3);
+        const paths = ['schools', 'classes', 'cohorts'];
+        for (let i = 0; i < 3; i++) {
+          const issue = result.error?.issues[i] as z.core.$ZodIssueInvalidType;
+          expect(issue.code).toEqual('invalid_type');
+          expect(issue.expected).toEqual('string');
+          expect(issue.message).toMatch(
+            /^Invalid input: expected string, received/,
+          );
+          expect(issue.path).toEqual(['orgIds', paths[i], 0]);
+        }
+      },
+    );
+
+    it.prop({ elem: fc.constantFrom('', '   ') })(
+      'rejects empty or whitespace-only strings in orgIds.schools, orgIds.classes, orgIds.cohorts',
+      ({ elem }) => {
+        const result = UserBaseSchema.safeParse({
+          ...$validBase,
+          orgIds: {
+            schools: [elem],
+            classes: [elem],
+            cohorts: [elem],
+          },
+        });
+        expect(result.success).toBe(false);
+        const paths = ['schools', 'classes', 'cohorts'];
+        for (let i = 0; i < 3; i++) {
+          expect(result.error?.issues[i]).toMatchObject({
+            code: 'too_small',
+            path: ['orgIds', paths[i], 0],
+          });
+        }
+      },
+    );
+  });
+
+  describe('invalid superRefine', () => {
+    it('rejects a user with neither schools/classes nor cohorts', () => {
+      const result = UserBaseSchema.safeParse({
+        ...$validBase,
+        orgIds: { schools: [], classes: [], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'custom',
+          message: 'Must have either schools and classes OR cohorts',
+          path: ['orgIds'],
+        },
+      ]);
+    });
+
+    it('rejects a user with both schools/classes and cohorts', () => {
+      const result = UserBaseSchema.safeParse({
+        ...$validBase,
+        orgIds: { schools: ['s1'], classes: ['c1'], cohorts: ['co1'] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'custom',
+          message: 'Must have either schools and classes OR cohorts',
+          path: ['orgIds'],
+        },
+      ]);
+    });
+
+    it('rejects a user with schools but no classes', () => {
+      const result = UserBaseSchema.safeParse({
+        ...$validBase,
+        orgIds: { schools: ['s1'], classes: [], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'custom',
+          message: 'Must have either schools and classes OR cohorts',
+          path: ['orgIds'],
+        },
+      ]);
+    });
+
+    it('rejects a user with classes but no schools', () => {
+      const result = UserBaseSchema.safeParse({
+        ...$validBase,
+        orgIds: { schools: [], classes: ['c1'], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'custom',
+          message: 'Must have either schools and classes OR cohorts',
+          path: ['orgIds'],
+        },
+      ]);
+    });
+  });
+});
+
+describe('ChildUserSchema', () => {
+  describe('valid', () => {
+    it('accepts a valid child', () => {
+      expect(() => ChildUserSchema.parse($validChild)).not.toThrow();
+    });
+
+    it.prop({ month: fc.integer({ min: 1, max: 12 }) })(
+      'accepts valid months (1-12)',
+      ({ month }) => {
+        expect(() =>
+          ChildUserSchema.parse({ ...$validChild, month }),
+        ).not.toThrow();
+      },
+    );
+
+    it.prop({
+      year: fc.integer({ min: CHILD_YEAR_MIN, max: CHILD_YEAR_MAX }),
+    })('accepts valid years (CHILD_YEAR_MIN-CHILD_YEAR_MAX)', ({ year }) => {
+      expect(() =>
+        ChildUserSchema.parse({ ...$validChild, year }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('invalid userType', () => {
+    it('rejects missing userType', () => {
+      const { userType: _, ...rest } = $validChild;
+      const result = ChildUserSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'invalid_value',
+        message: 'Invalid input: expected "child"',
+        path: ['userType'],
+        values: ['child'],
+      });
+    });
+
+    it('rejects non-child userType', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        userType: 'foo',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'invalid_value',
+        message: 'Invalid input: expected "child"',
+        path: ['userType'],
+        values: ['child'],
+      });
+    });
+  });
+
+  describe('invalid month', () => {
+    it('rejects missing month', () => {
+      const { month: _, ...rest } = $validChild;
+      const result = ChildUserSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('number');
+      expect(issue.message).toMatch(
+        /^Invalid input: expected number, received/,
+      );
+      expect(issue.path).toEqual(['month']);
+    });
+
+    it('rejects month below 1', () => {
+      const result = ChildUserSchema.safeParse({ ...$validChild, month: 0 });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'too_small',
+        inclusive: true,
+        message: 'Too small: expected number to be >=1',
+        minimum: 1,
+        origin: 'number',
+        path: ['month'],
+      });
+    });
+
+    it('rejects month above 12', () => {
+      const result = ChildUserSchema.safeParse({ ...$validChild, month: 13 });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'too_big',
+        inclusive: true,
+        message: 'Too big: expected number to be <=12',
+        maximum: 12,
+        origin: 'number',
+        path: ['month'],
+      });
+    });
+
+    it('rejects a non-integer month', () => {
+      const result = ChildUserSchema.safeParse({ ...$validChild, month: 1.5 });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'invalid_type',
+        expected: 'int',
+        format: 'safeint',
+        message: 'Invalid input: expected int, received number',
+        path: ['month'],
+      });
+    });
+  });
+
+  describe('invalid year', () => {
+    it('rejects missing year', () => {
+      const { year: _, ...rest } = $validChild;
+      const result = ChildUserSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Invalid input: expected number, received undefined',
+        path: ['year'],
+      });
+    });
+
+    it('rejects year below CHILD_YEAR_MIN', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        year: CHILD_YEAR_MIN - 1,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'too_small',
+        inclusive: true,
+        message: `Too small: expected number to be >=${CHILD_YEAR_MIN}`,
+        minimum: CHILD_YEAR_MIN,
+        origin: 'number',
+        path: ['year'],
+      });
+    });
+
+    it('rejects year above CHILD_YEAR_MAX', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        year: CHILD_YEAR_MAX + 1,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'too_big',
+        inclusive: true,
+        message: `Too big: expected number to be <=${CHILD_YEAR_MAX}`,
+        maximum: CHILD_YEAR_MAX,
+        origin: 'number',
+        path: ['year'],
+      });
+    });
+
+    it('rejects a non-integer year', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        year: 2020.5,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'invalid_type',
+        expected: 'int',
+        format: 'safeint',
+        message: 'Invalid input: expected int, received number',
+        path: ['year'],
+      });
+    });
+  });
+
+  describe('invalid superRefine', () => {
+    it('rejects multiple schools', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        orgIds: { schools: ['s1', 's2'], classes: ['c1'], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must have only one group',
+        path: ['orgIds'],
+      });
+    });
+
+    it('rejects multiple classes', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        orgIds: { schools: ['s1'], classes: ['c1', 'c2'], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must have only one group',
+        path: ['orgIds'],
+      });
+    });
+
+    it('rejects multiple cohorts', () => {
+      const result = ChildUserSchema.safeParse({
+        ...$validChild,
+        orgIds: { schools: [], classes: [], cohorts: ['co1', 'co2'] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must have only one group',
+        path: ['orgIds'],
+      });
+    });
+  });
+});
+
+describe('CaregiverUserSchema', () => {
+  describe('valid', () => {
+    it('accepts a valid caregiver', () => {
+      expect(() => CaregiverUserSchema.parse($validCaregiver)).not.toThrow();
+    });
+  });
+});
+
+describe('TeacherUserSchema', () => {
+  describe('valid', () => {
+    it('accepts a valid teacher', () => {
+      expect(() => TeacherUserSchema.parse($validTeacher)).not.toThrow();
+    });
+  });
+});
+
+describe('UserSchema', () => {
+  describe('valid', () => {
+    it('accepts a valid child', () => {
+      expect(() => UserSchema.parse($validChild)).not.toThrow();
+    });
+
+    it('accepts a valid caregiver', () => {
+      expect(() => UserSchema.parse($validCaregiver)).not.toThrow();
+    });
+
+    it('accepts a valid teacher', () => {
+      expect(() => UserSchema.parse($validTeacher)).not.toThrow();
+    });
+  });
+});
+
+describe('CreateUsersParamsSchema', () => {
+  describe('valid', () => {
+    it('accepts a valid params', () => {
+      expect(() => CreateUsersParamsSchema.parse($validParams)).not.toThrow();
+    });
+
+    it('strips unexpected props', () => {
+      const result = CreateUsersParamsSchema.safeParse({
+        ...$validParams,
+        unexpected: 'foo',
+      });
+      expect(result.data).toEqual({ ...$validParams });
+    });
+  });
+
+  describe('invalid root', () => {
+    it.prop({ nonObject: $nonObject })(
+      'rejects non-object root',
+      ({ nonObject }) => {
+        const result = CreateUsersParamsSchema.safeParse(nonObject);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('object');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected object, received/,
+        );
+        expect(issue.path).toEqual([]);
+      },
+    );
+
+    it('rejects missing props', () => {
+      const result = CreateUsersParamsSchema.safeParse({});
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(2);
+      const issues = result.error?.issues as z.core.$ZodIssueInvalidType[];
+      for (const [idx, [expected, path]] of [
+        ['string', 'siteId'],
+        ['array', 'users'],
+      ].entries()) {
+        const issue = issues[idx];
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual(expected);
+        expect(issue.message).toMatch(
+          new RegExp(`^Invalid input: expected ${expected}, received`),
+        );
+        expect(issue.path).toEqual([path]);
+      }
+    });
+  });
+
+  describe('invalid siteId', () => {
+    it.prop({ nonString: $nonString })(
+      'rejects non-string siteId',
+      ({ nonString }) => {
+        const result = CreateUsersParamsSchema.safeParse({
+          ...$validParams,
+          siteId: nonString,
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('string');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected string, received/,
+        );
+        expect(issue.path).toEqual(['siteId']);
+      },
+    );
+
+    it.prop({ empty: fc.constantFrom('', '   ') })(
+      'rejects empty or whitespace-only siteId',
+      ({ empty }) => {
+        const result = CreateUsersParamsSchema.safeParse({
+          ...$validParams,
+          siteId: empty,
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('too_small');
+        expect(issue.message).toMatch(
+          /^Too small: expected string to have >=1 characters/,
+        );
+        expect(issue.path).toEqual(['siteId']);
+      },
+    );
+  });
+
+  describe('invalid users', () => {
+    it.prop({ users: $nonArray })('rejects non-array users', ({ users }) => {
+      const result = CreateUsersParamsSchema.safeParse({
+        ...$validParams,
+        users,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('array');
+      expect(issue.message).toMatch(/^Invalid input: expected array, received/);
+      expect(issue.path).toEqual(['users']);
+    });
+
+    it.prop({ user: $nonObject })(
+      'rejects non-object users items',
+      ({ user }) => {
+        const result = CreateUsersParamsSchema.safeParse({
+          ...$validParams,
+          users: [user],
+        });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues.length).toBe(1);
+        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('object');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected object, received/,
+        );
+        expect(issue.path).toEqual(['users', 0]);
+      },
+    );
+  });
+
+  describe('invalid superRefine', () => {
+    it('rejects empty users array', () => {
+      const result = CreateUsersParamsSchema.safeParse({
+        ...$validParams,
+        users: [],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must have at least one user',
+        path: ['users'],
+      });
+    });
+
+    it('rejects duplicate users', () => {
+      const result = CreateUsersParamsSchema.safeParse({
+        ...$validParams,
+        users: [$validChild, $validChild],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(2);
+      const issues = result.error?.issues as z.core.$ZodIssueCustom[];
+      for (const [idx, issue] of issues.entries()) {
+        expect(issue.code).toEqual('custom');
+        expect(issue.message).toEqual('Must be unique');
+        expect(issue.path).toEqual([idx, 'id']);
+      }
+    });
+  });
+});

--- a/src/firebase-functions/create-users.test.ts
+++ b/src/firebase-functions/create-users.test.ts
@@ -17,9 +17,6 @@ const $nonArray = fc.anything().filter((v) => !Array.isArray(v));
 /** Arbitrary: a non-object value */
 const $nonObject = fc.anything().filter((v) => typeof v !== 'object');
 
-/** Arbitrary: a non-string value */
-const $nonString = fc.anything().filter((v) => typeof v !== 'string');
-
 /** Fixture: a valid user base */
 const $validBase = {
   id: 'u1',
@@ -116,34 +113,6 @@ describe('UserBaseSchema', () => {
     });
   });
 
-  describe('invalid id', () => {
-    it.prop({ id: $nonString })('rejects non-string id', ({ id }) => {
-      const result = UserBaseSchema.safeParse({ ...$validBase, id });
-      expect(result.success).toBe(false);
-      expect(result.error?.issues.length).toBe(1);
-      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
-      expect(issue.code).toEqual('invalid_type');
-      expect(issue.expected).toEqual('string');
-      expect(issue.message).toMatch(
-        /^Invalid input: expected string, received/,
-      );
-      expect(issue.path).toEqual(['id']);
-    });
-
-    it.prop({ id: fc.constantFrom('', '   ') })(
-      'rejects empty or whitespace-only id',
-      ({ id }) => {
-        const result = UserBaseSchema.safeParse({ ...$validBase, id });
-        expect(result.success).toBe(false);
-        expect(result.error?.issues.length).toBe(1);
-        expect(result.error?.issues[0]).toMatchObject({
-          code: 'too_small',
-          path: ['id'],
-        });
-      },
-    );
-  });
-
   describe('invalid orgIds', () => {
     it.prop({ orgIds: $nonObject })(
       'rejects non-object orgIds',
@@ -190,53 +159,21 @@ describe('UserBaseSchema', () => {
       },
     );
 
-    it.prop({ nonString: $nonString })(
-      'rejects non-strings in orgIds.schools, orgIds.classes, orgIds.cohorts',
-      ({ nonString }) => {
-        const result = UserBaseSchema.safeParse({
-          ...$validBase,
-          orgIds: {
-            schools: [nonString],
-            classes: [nonString],
-            cohorts: [nonString],
-          },
-        });
-        expect(result.success).toBe(false);
-        expect(result.error?.issues.length).toBe(3);
-        const paths = ['schools', 'classes', 'cohorts'];
-        for (let i = 0; i < 3; i++) {
-          const issue = result.error?.issues[i] as z.core.$ZodIssueInvalidType;
-          expect(issue.code).toEqual('invalid_type');
-          expect(issue.expected).toEqual('string');
-          expect(issue.message).toMatch(
-            /^Invalid input: expected string, received/,
-          );
-          expect(issue.path).toEqual(['orgIds', paths[i], 0]);
-        }
-      },
-    );
-
-    it.prop({ elem: fc.constantFrom('', '   ') })(
-      'rejects empty or whitespace-only strings in orgIds.schools, orgIds.classes, orgIds.cohorts',
-      ({ elem }) => {
-        const result = UserBaseSchema.safeParse({
-          ...$validBase,
-          orgIds: {
-            schools: [elem],
-            classes: [elem],
-            cohorts: [elem],
-          },
-        });
-        expect(result.success).toBe(false);
-        const paths = ['schools', 'classes', 'cohorts'];
-        for (let i = 0; i < 3; i++) {
-          expect(result.error?.issues[i]).toMatchObject({
-            code: 'too_small',
-            path: ['orgIds', paths[i], 0],
-          });
-        }
-      },
-    );
+    it('rejects missing orgIds sub-fields', () => {
+      const result = UserBaseSchema.safeParse({ ...$validBase, orgIds: {} });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(3);
+      const paths = ['schools', 'classes', 'cohorts'];
+      for (const [i, path] of paths.entries()) {
+        const issue = result.error?.issues[i] as z.core.$ZodIssueInvalidType;
+        expect(issue.code).toEqual('invalid_type');
+        expect(issue.expected).toEqual('array');
+        expect(issue.message).toMatch(
+          /^Invalid input: expected array, received/,
+        );
+        expect(issue.path).toEqual(['orgIds', path]);
+      }
+    });
   });
 
   describe('invalid superRefine', () => {
@@ -553,6 +490,59 @@ describe('UserSchema', () => {
       expect(() => UserSchema.parse($validTeacher)).not.toThrow();
     });
   });
+
+  describe('invalid userType', () => {
+    it('rejects an unknown userType', () => {
+      const result = UserSchema.safeParse({
+        ...$validChild,
+        userType: 'admin',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'invalid_union',
+          errors: [],
+          note: 'No matching discriminator',
+          discriminator: 'userType',
+          path: ['userType'],
+          message: 'Invalid input',
+        },
+      ]);
+    });
+
+    it('rejects a missing userType', () => {
+      const { userType: _, ...rest } = $validChild;
+      const result = UserSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'invalid_union',
+          errors: [],
+          note: 'No matching discriminator',
+          discriminator: 'userType',
+          path: ['userType'],
+          message: 'Invalid input',
+        },
+      ]);
+    });
+  });
+
+  describe('invalid superRefine (inherited)', () => {
+    it('rejects a user with no org group', () => {
+      const result = UserSchema.safeParse({
+        ...$validChild,
+        orgIds: { schools: [], classes: [], cohorts: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'custom',
+          message: 'Must have either schools and classes OR cohorts',
+          path: ['orgIds'],
+        },
+      ]);
+    });
+  });
 });
 
 describe('CreateUsersParamsSchema', () => {
@@ -605,45 +595,6 @@ describe('CreateUsersParamsSchema', () => {
         expect(issue.path).toEqual([path]);
       }
     });
-  });
-
-  describe('invalid siteId', () => {
-    it.prop({ nonString: $nonString })(
-      'rejects non-string siteId',
-      ({ nonString }) => {
-        const result = CreateUsersParamsSchema.safeParse({
-          ...$validParams,
-          siteId: nonString,
-        });
-        expect(result.success).toBe(false);
-        expect(result.error?.issues.length).toBe(1);
-        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
-        expect(issue.code).toEqual('invalid_type');
-        expect(issue.expected).toEqual('string');
-        expect(issue.message).toMatch(
-          /^Invalid input: expected string, received/,
-        );
-        expect(issue.path).toEqual(['siteId']);
-      },
-    );
-
-    it.prop({ empty: fc.constantFrom('', '   ') })(
-      'rejects empty or whitespace-only siteId',
-      ({ empty }) => {
-        const result = CreateUsersParamsSchema.safeParse({
-          ...$validParams,
-          siteId: empty,
-        });
-        expect(result.success).toBe(false);
-        expect(result.error?.issues.length).toBe(1);
-        const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
-        expect(issue.code).toEqual('too_small');
-        expect(issue.message).toMatch(
-          /^Too small: expected string to have >=1 characters/,
-        );
-        expect(issue.path).toEqual(['siteId']);
-      },
-    );
   });
 
   describe('invalid users', () => {

--- a/src/firebase-functions/create-users.ts
+++ b/src/firebase-functions/create-users.ts
@@ -35,7 +35,7 @@ export const UserBaseSchema = z
   .superRefine((data, ctx) => {
     // All users must have either schools+classes xor cohorts
     const hasSchoolClass =
-      data.orgIds.schools.length > 0 && data.orgIds.classes.length;
+      data.orgIds.schools.length > 0 && data.orgIds.classes.length > 0;
     const hasCohort = data.orgIds.cohorts.length > 0;
     const hasAtLeastOneGroup = hasSchoolClass || hasCohort;
     const hasBothGroupTypes = hasSchoolClass && hasCohort;

--- a/src/firebase-functions/create-users.ts
+++ b/src/firebase-functions/create-users.ts
@@ -1,0 +1,137 @@
+import * as z from 'zod';
+import { CHILD_YEAR_MAX, CHILD_YEAR_MIN } from '../csv/user-csv';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+
+/** @deprecated */
+export const CreateUserSchema = z.object({
+  id: z.string(),
+  userType: z.enum(['admin', 'teacher', 'student', 'parent']),
+  month: z.string().optional(),
+  year: z.string().optional(),
+  caregiverId: z.string().optional(),
+  teacherId: z.string().optional(),
+  site: z.string(),
+  school: z.string().optional(),
+  class: z.string().optional(),
+  cohort: z.string().optional(),
+  orgIds: z.object({
+    schools: z.array(z.string()),
+    classes: z.array(z.string()),
+    districts: z.array(z.string()).nonempty(),
+    groups: z.array(z.string()),
+  }),
+});
+
+/** Base schema for CreateUsersParamsSchema.users items */
+export const UserBaseSchema = z
+  .object({
+    id: NonEmptyStringSchema,
+    orgIds: z.object({
+      schools: z.array(NonEmptyStringSchema),
+      classes: z.array(NonEmptyStringSchema),
+      cohorts: z.array(NonEmptyStringSchema),
+    }),
+  })
+  .superRefine((data, ctx) => {
+    // All users must have either schools+classes xor cohorts
+    const hasSchoolClass =
+      data.orgIds.schools.length > 0 && data.orgIds.classes.length;
+    const hasCohort = data.orgIds.cohorts.length > 0;
+    const hasAtLeastOneGroup = hasSchoolClass || hasCohort;
+    const hasBothGroupTypes = hasSchoolClass && hasCohort;
+    if (!hasAtLeastOneGroup || hasBothGroupTypes) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Must have either schools and classes OR cohorts',
+        path: ['orgIds'],
+        input: data,
+      });
+    }
+  });
+
+/** Schema for CreateUsersParamsSchema.users items where userType is 'child' */
+export const ChildUserSchema = UserBaseSchema.extend({
+  userType: z.literal('child'),
+  month: z.int().min(1).max(12),
+  year: z.int().min(CHILD_YEAR_MIN).max(CHILD_YEAR_MAX),
+}).superRefine((data, ctx) => {
+  // Children must have only one group
+  const hasSchools = data.orgIds.schools.length > 1;
+  const hasClasses = data.orgIds.classes.length > 1;
+  const hasCohorts = data.orgIds.cohorts.length > 1;
+  if (hasSchools || hasClasses || hasCohorts) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Must have only one group',
+      path: ['orgIds'],
+      input: data,
+    });
+  }
+});
+
+/** Schema for CreateUsersParamsSchema.users items where userType is 'caregiver' */
+export const CaregiverUserSchema = UserBaseSchema.extend({
+  userType: z.literal('caregiver'),
+});
+
+/** Schema for CreateUsersParamsSchema.users items where userType is 'teacher' */
+export const TeacherUserSchema = UserBaseSchema.extend({
+  userType: z.literal('teacher'),
+});
+
+/** Schema for CreateUsersParamsSchema.users items */
+export const UserSchema = z.discriminatedUnion('userType', [
+  ChildUserSchema,
+  CaregiverUserSchema,
+  TeacherUserSchema,
+]);
+
+/** Parameters schema for `createUsers` Firebase Function */
+export const CreateUsersParamsSchema = z
+  .object({
+    siteId: NonEmptyStringSchema,
+    users: z.array(UserSchema),
+  })
+  .superRefine((data, ctx) => {
+    // Users array must be non-empty
+    if (data.users.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Must have at least one user',
+        path: ['users'],
+      });
+      return;
+    }
+
+    // Users must have unique ids
+    const seen = new Map<string, number[]>();
+    data.users.forEach((user, idx) => {
+      const idxs = seen.get(user.id) ?? [];
+      idxs.push(idx);
+      seen.set(user.id, idxs);
+    });
+    for (const idxs of seen.values()) {
+      if (idxs.length < 2) continue;
+      idxs.forEach((idx) => {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Must be unique',
+          path: [idx, 'id'],
+          input: data.users[idx].id,
+        });
+      });
+    }
+  });
+
+/** Parameters type for `createUsers` Firebase Function */
+export type CreateUsersParams = z.infer<typeof CreateUsersParamsSchema>;
+
+/** Result type for `createUsers` Firebase Function */
+export type CreateUsersResult = {
+  users: {
+    id: string;
+    email: string;
+    password: string;
+    uid: string;
+  }[];
+};

--- a/src/firebase-functions/create-users.ts
+++ b/src/firebase-functions/create-users.ts
@@ -99,6 +99,7 @@ export const CreateUsersParamsSchema = z
         code: 'custom',
         message: 'Must have at least one user',
         path: ['users'],
+        input: data.users,
       });
       return;
     }

--- a/src/firebase-functions/get-sync-status.test.ts
+++ b/src/firebase-functions/get-sync-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { GetSyncStatusParamsSchema } from './get-sync-status';
+
+describe('GetSyncStatusParamsSchema', () => {
+  it('accepts valid props', () => {
+    expect(GetSyncStatusParamsSchema.parse({ siteId: 'foo' })).toEqual({
+      siteId: 'foo',
+    });
+  });
+
+  it('strips unexpected props', () => {
+    const result = GetSyncStatusParamsSchema.parse({
+      siteId: 'foo',
+      unexpected: 'bar',
+      another: 'baz',
+    });
+    expect(result).toEqual({ siteId: 'foo' });
+  });
+
+  it('rejects missing siteId', () => {
+    const result = GetSyncStatusParamsSchema.safeParse({});
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Invalid input: expected string, received undefined',
+        path: ['siteId'],
+      },
+    ]);
+  });
+});

--- a/src/firebase-functions/get-sync-status.ts
+++ b/src/firebase-functions/get-sync-status.ts
@@ -1,0 +1,24 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+
+/** Parameters schema for `getSyncStatus` Firebase Function */
+export const GetSyncStatusParamsSchema = z.object({
+  siteId: NonEmptyStringSchema,
+});
+
+/** Parameters type for `getSyncStatus` Firebase Function */
+export type GetSyncStatusParams = z.infer<typeof GetSyncStatusParamsSchema>;
+
+/** Result type for `getSyncStatus` Firebase Function */
+export type GetSyncStatusResult = {
+  assignments: {
+    complete: number;
+    failed: number;
+    pending: number;
+  };
+  users: {
+    complete: number;
+    failed: number;
+    pending: number;
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import {
   LinkUsersCsvSchema,
   validateLinkUsersCsv,
 } from './deprecated/users-link';
+import {
+  CreateUserSchema,
+  CreateUsersParamsSchema,
+} from './firebase-functions/create-users';
 import { GetSiteOverviewParamsSchema } from './firebase-functions/get-site-overview';
 import { makeCustomIssue } from './util/issues';
 
@@ -452,25 +456,6 @@ const UserSchema = z.object({
   testData: z.boolean().optional(),
 });
 
-const CreateUserSchema = z.object({
-  id: z.string(),
-  userType: z.enum(['admin', 'teacher', 'student', 'parent']),
-  month: z.string().optional(),
-  year: z.string().optional(),
-  caregiverId: z.string().optional(),
-  teacherId: z.string().optional(),
-  site: z.string(),
-  school: z.string().optional(),
-  class: z.string().optional(),
-  cohort: z.string().optional(),
-  orgIds: z.object({
-    schools: z.array(z.string()),
-    classes: z.array(z.string()),
-    districts: z.array(z.string()).nonempty(),
-    groups: z.array(z.string()),
-  }),
-});
-
 const OrgSchema = z.object({
   archived: z.boolean(),
   classes: z.array(z.string()).optional(),
@@ -530,6 +515,7 @@ export {
   CreateOrgSchema,
   CreateSchoolSchema,
   CreateUserSchema,
+  CreateUsersParamsSchema,
   CsvHeadersSchema,
   combineUserCsvIssues,
   DistrictSchema,
@@ -590,7 +576,12 @@ export type CreateDistrictType = z.infer<typeof CreateDistrictSchema>;
 export type CreateGroupType = z.infer<typeof CreateGroupSchema>;
 export type CreateOrgType = z.infer<typeof CreateOrgSchema>;
 export type CreateSchoolType = z.infer<typeof CreateSchoolSchema>;
+/** @deprecated */
 export type CreateUserType = z.infer<typeof CreateUserSchema>;
+export type {
+  CreateUsersParams,
+  CreateUsersResult,
+} from './firebase-functions/create-users';
 /** @deprecated */
 export type CsvHeadersType = z.infer<typeof CsvHeadersSchema>;
 export type DistrictType = z.infer<typeof DistrictSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   CreateUsersParamsSchema,
 } from './firebase-functions/create-users';
 import { GetSiteOverviewParamsSchema } from './firebase-functions/get-site-overview';
+import { GetSyncStatusParamsSchema } from './firebase-functions/get-sync-status';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -520,6 +521,7 @@ export {
   combineUserCsvIssues,
   DistrictSchema,
   GetSiteOverviewParamsSchema,
+  GetSyncStatusParamsSchema,
   GroupSchema,
   H3CellSchema,
   LatLonSourceSchema,
@@ -590,6 +592,10 @@ export type {
   GetSiteOverviewParams,
   GetSiteOverviewResult,
 } from './firebase-functions/get-site-overview';
+export type {
+  GetSyncStatusParams,
+  GetSyncStatusResult,
+} from './firebase-functions/get-sync-status';
 export type GroupType = z.infer<typeof GroupSchema>;
 export type LatLonSourceType = z.infer<typeof LatLonSourceSchema>;
 export type LegalInfoType = z.infer<typeof LegalInfoSchema>;


### PR DESCRIPTION
This PR adds schemas/types for two Firebase Functions supporting the Add Users backend: `createUsers` and `getSyncStatus`.

- Add exported schemas `CreateUsersParamsSchema`, `GetSyncStatusParamsSchema`
- Add exported types `CreateUsersParams`, `CreateUsersResult`, `GetSyncStatusParams`, `GetSyncStatusResult`
- Deprecate type `CreateUserType`

## TL;DR

### createUsers I/O

```ts
interface CreateUsersParams {
  siteId: string;
  users: {
    userType: "child" | "caregiver" | "teacher";
    id: string;
    orgIds: {
      schools: string[];
      classes: string[];
      cohorts: string[];
    };
    month?: number; // child-only
    year?: number; // child-only
  }[];
}

interface CreateUsersResult {
  users: {
    id: string;
    email: string;
    password: string;
    uid: string;
  }[];
}
```

### getSyncStatus I/O

```ts
interface GetSyncStatusParams {
  siteId: string;
}

interface GetSyncStatusResult {
  assignments: {
    complete: number;
    failed: number;
    pending: number;
  };
  users: {
    complete: number;
    failed: number;
    pending: number;
  };
}
```