### PR TITLE
List users and update user

### DIFF
--- a/src/firebase-functions/list-users.test.ts
+++ b/src/firebase-functions/list-users.test.ts
@@ -3,7 +3,10 @@ import type * as z from 'zod';
 import { ListUsersParamsSchema } from './list-users';
 
 /** Fixture: minimal valid params */
-const $valid = { orgType: 'schools' as const, orgId: 'o1' };
+const $valid = { orgType: 'school' as const, orgId: 'o1' };
+
+/** Fixture: the default orderBy applied when none is provided */
+const $defaultOrderBy = { field: 'createdAt', direction: 'desc' };
 
 describe('ListUsersParamsSchema', () => {
   describe('valid', () => {
@@ -17,10 +20,22 @@ describe('ListUsersParamsSchema', () => {
           ...$valid,
           page: 0,
           pageLimit: 50,
-          restrictToActiveUsers: true,
-          restrictToEnabledUsers: true,
+          orderBy: { field: 'email', direction: 'asc' },
+          excludeArchived: true,
+          excludeDisabled: true,
         }),
       ).not.toThrow();
+    });
+
+    it('defaults orderBy to createdAt (newest first)', () => {
+      const result = ListUsersParamsSchema.parse($valid);
+      expect(result.orderBy).toEqual($defaultOrderBy);
+    });
+
+    it('keeps a provided orderBy', () => {
+      const orderBy = { field: 'email', direction: 'asc' as const };
+      const result = ListUsersParamsSchema.parse({ ...$valid, orderBy });
+      expect(result.orderBy).toEqual(orderBy);
     });
 
     it('strips unexpected props', () => {
@@ -28,7 +43,7 @@ describe('ListUsersParamsSchema', () => {
         ...$valid,
         unexpected: 'foo',
       });
-      expect(result.data).toEqual({ ...$valid });
+      expect(result.data).toEqual({ ...$valid, orderBy: $defaultOrderBy });
     });
   });
 
@@ -63,6 +78,26 @@ describe('ListUsersParamsSchema', () => {
       expect(result.success).toBe(false);
       expect(result.error?.issues.length).toBe(1);
       expect(result.error?.issues[0].path).toEqual(['orgId']);
+    });
+
+    it('rejects an invalid orderBy field', () => {
+      const result = ListUsersParamsSchema.safeParse({
+        ...$valid,
+        orderBy: { field: 'username', direction: 'asc' },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['orderBy', 'field']);
+    });
+
+    it('rejects an invalid orderBy direction', () => {
+      const result = ListUsersParamsSchema.safeParse({
+        ...$valid,
+        orderBy: { field: 'createdAt', direction: 'sideways' },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['orderBy', 'direction']);
     });
   });
 });

--- a/src/firebase-functions/list-users.test.ts
+++ b/src/firebase-functions/list-users.test.ts
@@ -1,6 +1,7 @@
+import { FunctionsError } from 'firebase/functions';
 import { describe, expect, it } from 'vitest';
 import type * as z from 'zod';
-import { ListUsersParamsSchema } from './list-users';
+import { ListUsersErrorSchema, ListUsersParamsSchema } from './list-users';
 
 /** Fixture: minimal valid params */
 const $valid = { orgType: 'school' as const, orgId: 'o1' };
@@ -98,6 +99,28 @@ describe('ListUsersParamsSchema', () => {
       expect(result.success).toBe(false);
       expect(result.error?.issues.length).toBe(1);
       expect(result.error?.issues[0].path).toEqual(['orderBy', 'direction']);
+    });
+  });
+});
+
+describe('ListUsersErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'users[0].uid', message: 'Must be non-empty' }],
+      });
+      expect(() => ListUsersErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => ListUsersErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => ListUsersErrorSchema.parse(err)).not.toThrow();
     });
   });
 });

--- a/src/firebase-functions/list-users.test.ts
+++ b/src/firebase-functions/list-users.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type * as z from 'zod';
+import { ListUsersParamsSchema } from './list-users';
+
+/** Fixture: minimal valid params */
+const $valid = { orgType: 'schools' as const, orgId: 'o1' };
+
+describe('ListUsersParamsSchema', () => {
+  describe('valid', () => {
+    it('accepts minimal valid params', () => {
+      expect(() => ListUsersParamsSchema.parse($valid)).not.toThrow();
+    });
+
+    it('accepts optional params', () => {
+      expect(() =>
+        ListUsersParamsSchema.parse({
+          ...$valid,
+          page: 0,
+          pageLimit: 50,
+          restrictToActiveUsers: true,
+          restrictToEnabledUsers: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('strips unexpected props', () => {
+      const result = ListUsersParamsSchema.safeParse({
+        ...$valid,
+        unexpected: 'foo',
+      });
+      expect(result.data).toEqual({ ...$valid });
+    });
+  });
+
+  describe('invalid', () => {
+    it('rejects missing props', () => {
+      const result = ListUsersParamsSchema.safeParse({});
+      expect(result.success).toBe(false);
+      const issues = result.error?.issues as z.core.$ZodIssue[];
+      expect(issues.length).toBe(2);
+      expect(issues.map((i) => i.path[0]).sort()).toEqual(['orgId', 'orgType']);
+    });
+
+    it('rejects an invalid orgType', () => {
+      const result = ListUsersParamsSchema.safeParse({
+        ...$valid,
+        orgType: 'foo',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['orgType']);
+    });
+
+    it('rejects a non-integer page', () => {
+      const result = ListUsersParamsSchema.safeParse({ ...$valid, page: 1.5 });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['page']);
+    });
+
+    it('rejects an empty orgId', () => {
+      const result = ListUsersParamsSchema.safeParse({ ...$valid, orgId: '' });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['orgId']);
+    });
+  });
+});

--- a/src/firebase-functions/list-users.ts
+++ b/src/firebase-functions/list-users.ts
@@ -3,32 +3,36 @@ import { NonEmptyStringSchema } from '../shared/non-empty-string';
 
 /** Parameters schema for `listUsers` Firebase Function */
 export const ListUsersParamsSchema = z.object({
-  orgType: z.enum(['districts', 'schools', 'classes', 'groups']),
+  orgType: z.enum(['site', 'school', 'class', 'cohort']),
   orgId: NonEmptyStringSchema,
   page: z.int().min(0).optional(),
   pageLimit: z.int().min(1).optional(),
-  // Restrict to active users, i.e., where `archived` is `false`
-  restrictToActiveUsers: z.boolean().optional(),
-  // Restrict to enabled users, i.e., where `disabled` is `false`
-  restrictToEnabledUsers: z.boolean().optional(),
+  // Field and direction to order results by; defaults to newest first
+  orderBy: z
+    .object({
+      field: z.enum(['createdAt', 'email', 'userType']),
+      direction: z.enum(['asc', 'desc']),
+    })
+    .default({ field: 'createdAt', direction: 'desc' }),
+  // Exclude archived users, i.e., where `archived` is `true`
+  excludeArchived: z.boolean().optional(),
+  // Exclude disabled users, i.e., where `disabled` is `true`
+  excludeDisabled: z.boolean().optional(),
 });
 
 /** Parameters type for `listUsers` Firebase Function */
 export type ListUsersParams = z.infer<typeof ListUsersParamsSchema>;
 
-/** A user returned by the `listUsers` Firebase Function */
-export type ListUsersUser = {
-  id: string;
-  username: string;
-  email: string;
-  // NB: frontend-facing userType. The database stores `student`/`parent`; the
-  // backend converts these to `child`/`caregiver` for the frontend.
-  userType: 'admin' | 'teacher' | 'child' | 'caregiver';
-  archived: boolean;
-  disabled: boolean;
-};
-
 /** Result type for `listUsers` Firebase Function */
 export type ListUsersResult = {
-  users: ListUsersUser[];
+  users: {
+    uid: string;
+    username: string;
+    email: string;
+    // NB: frontend-facing userType. The database stores `student`/`parent`; the
+    // backend converts these to `child`/`caregiver` for the frontend.
+    userType: 'admin' | 'teacher' | 'child' | 'caregiver';
+    archived: boolean;
+    disabled: boolean;
+  }[];
 };

--- a/src/firebase-functions/list-users.ts
+++ b/src/firebase-functions/list-users.ts
@@ -1,0 +1,34 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+
+/** Parameters schema for `listUsers` Firebase Function */
+export const ListUsersParamsSchema = z.object({
+  orgType: z.enum(['districts', 'schools', 'classes', 'groups']),
+  orgId: NonEmptyStringSchema,
+  page: z.int().min(0).optional(),
+  pageLimit: z.int().min(1).optional(),
+  // Restrict to active users, i.e., where `archived` is `false`
+  restrictToActiveUsers: z.boolean().optional(),
+  // Restrict to enabled users, i.e., where `disabled` is `false`
+  restrictToEnabledUsers: z.boolean().optional(),
+});
+
+/** Parameters type for `listUsers` Firebase Function */
+export type ListUsersParams = z.infer<typeof ListUsersParamsSchema>;
+
+/** A user returned by the `listUsers` Firebase Function */
+export type ListUsersUser = {
+  id: string;
+  username: string;
+  email: string;
+  // NB: frontend-facing userType. The database stores `student`/`parent`; the
+  // backend converts these to `child`/`caregiver` for the frontend.
+  userType: 'admin' | 'teacher' | 'child' | 'caregiver';
+  archived: boolean;
+  disabled: boolean;
+};
+
+/** Result type for `listUsers` Firebase Function */
+export type ListUsersResult = {
+  users: ListUsersUser[];
+};

--- a/src/firebase-functions/list-users.ts
+++ b/src/firebase-functions/list-users.ts
@@ -1,7 +1,12 @@
 import * as z from 'zod';
 import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
 
-/** Parameters schema for `listUsers` Firebase Function */
+/** Parameters schema for `listUsers` Firebase Function. */
 export const ListUsersParamsSchema = z.object({
   orgType: z.enum(['site', 'school', 'class', 'cohort']),
   orgId: NonEmptyStringSchema,
@@ -20,10 +25,10 @@ export const ListUsersParamsSchema = z.object({
   excludeDisabled: z.boolean().optional(),
 });
 
-/** Parameters type for `listUsers` Firebase Function */
+/** Inferred type of {@link ListUsersParamsSchema}. */
 export type ListUsersParams = z.infer<typeof ListUsersParamsSchema>;
 
-/** Result type for `listUsers` Firebase Function */
+/** Result type for `listUsers` Firebase Function. */
 export type ListUsersResult = {
   users: {
     uid: string;
@@ -36,3 +41,13 @@ export type ListUsersResult = {
     disabled: boolean;
   }[];
 };
+
+/** Error schema for `listUsers` Firebase Function. */
+export const ListUsersErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link ListUsersErrorSchema}. */
+export type ListUsersError = z.infer<typeof ListUsersErrorSchema>;

--- a/src/firebase-functions/update-user-info.test.ts
+++ b/src/firebase-functions/update-user-info.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type * as z from 'zod';
+import { UpdateUserInfoParamsSchema } from './update-user-info';
+
+/** Fixture: valid params */
+const $valid = {
+  users: [
+    { uid: 'u1', archived: true },
+    { uid: 'u2', disabled: false },
+    { uid: 'u3', archived: true, disabled: true },
+  ],
+};
+
+describe('UpdateUserInfoParamsSchema', () => {
+  describe('valid', () => {
+    it('accepts valid params', () => {
+      expect(() => UpdateUserInfoParamsSchema.parse($valid)).not.toThrow();
+    });
+
+    it('accepts a single edited field', () => {
+      expect(() =>
+        UpdateUserInfoParamsSchema.parse({
+          users: [{ uid: 'u1', archived: true }],
+        }),
+      ).not.toThrow();
+    });
+
+    it('strips unexpected props', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [{ uid: 'u1', archived: true, unexpected: 'foo' }],
+      });
+      expect(result.data).toEqual({ users: [{ uid: 'u1', archived: true }] });
+    });
+  });
+
+  describe('invalid root', () => {
+    it('rejects a missing users prop', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({});
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('array');
+      expect(issue.path).toEqual(['users']);
+    });
+  });
+
+  describe('invalid users', () => {
+    it('rejects a user with a missing uid', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [{ archived: true }],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('string');
+      expect(issue.path).toEqual(['users', 0, 'uid']);
+    });
+
+    it('rejects a user with an empty uid', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [{ uid: '', archived: true }],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0].path).toEqual(['users', 0, 'uid']);
+    });
+
+    it('rejects a non-boolean field', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [{ uid: 'u1', archived: 'yes' }],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      const issue = result.error?.issues[0] as z.core.$ZodIssueInvalidType;
+      expect(issue.code).toEqual('invalid_type');
+      expect(issue.expected).toEqual('boolean');
+      expect(issue.path).toEqual(['users', 0, 'archived']);
+    });
+  });
+
+  describe('invalid superRefine', () => {
+    it('rejects an empty users array', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({ users: [] });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must have at least one user',
+        path: ['users'],
+      });
+    });
+
+    it('rejects a user with no edited fields', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [{ uid: 'u1' }],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(1);
+      expect(result.error?.issues[0]).toEqual({
+        code: 'custom',
+        message: 'Must provide at least one field to update',
+        path: ['users', 0],
+      });
+    });
+
+    it('rejects duplicate uids', () => {
+      const result = UpdateUserInfoParamsSchema.safeParse({
+        users: [
+          { uid: 'dup', archived: true },
+          { uid: 'dup', disabled: true },
+        ],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.length).toBe(2);
+      const issues = result.error?.issues as z.core.$ZodIssueCustom[];
+      for (const [idx, issue] of issues.entries()) {
+        expect(issue.code).toEqual('custom');
+        expect(issue.message).toEqual('Must be unique');
+        expect(issue.path).toEqual(['users', idx, 'uid']);
+      }
+    });
+  });
+});

--- a/src/firebase-functions/update-user-info.test.ts
+++ b/src/firebase-functions/update-user-info.test.ts
@@ -1,6 +1,10 @@
+import { FunctionsError } from 'firebase/functions';
 import { describe, expect, it } from 'vitest';
 import type * as z from 'zod';
-import { UpdateUserInfoParamsSchema } from './update-user-info';
+import {
+  UpdateUserInfoErrorSchema,
+  UpdateUserInfoParamsSchema,
+} from './update-user-info';
 
 /** Fixture: valid params */
 const $valid = {
@@ -120,6 +124,28 @@ describe('UpdateUserInfoParamsSchema', () => {
         expect(issue.message).toEqual('Must be unique');
         expect(issue.path).toEqual(['users', idx, 'uid']);
       }
+    });
+  });
+});
+
+describe('UpdateUserInfoErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'users[0].uid', message: 'Must be non-empty' }],
+      });
+      expect(() => UpdateUserInfoErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => UpdateUserInfoErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => UpdateUserInfoErrorSchema.parse(err)).not.toThrow();
     });
   });
 });

--- a/src/firebase-functions/update-user-info.ts
+++ b/src/firebase-functions/update-user-info.ts
@@ -1,0 +1,83 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+
+/**
+ * A single user update accepted by the `updateUserInfo` Firebase Function.
+ *
+ * Holds primitive, self-contained properties that only affect the user's own
+ * document (i.e., not relationships to other entities such as orgs). Add new
+ * optional fields here as more such properties become editable.
+ */
+export const UpdateUserInfoUserSchema = z.object({
+  uid: NonEmptyStringSchema,
+  archived: z.boolean().optional(),
+  disabled: z.boolean().optional(),
+});
+
+/** The editable fields on a user, excluding the `uid` identifier */
+const EDITABLE_FIELDS = ['archived', 'disabled'] as const;
+
+/** Parameters schema for `updateUserInfo` Firebase Function */
+export const UpdateUserInfoParamsSchema = z
+  .object({
+    users: z.array(UpdateUserInfoUserSchema),
+  })
+  .superRefine((data, ctx) => {
+    // Users array must be non-empty
+    if (data.users.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Must have at least one user',
+        path: ['users'],
+        input: data.users,
+      });
+      return;
+    }
+
+    // Each user must edit at least one field
+    data.users.forEach((user, idx) => {
+      const hasEdit = EDITABLE_FIELDS.some(
+        (field) => user[field] !== undefined,
+      );
+      if (!hasEdit) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Must provide at least one field to update',
+          path: ['users', idx],
+          input: user,
+        });
+      }
+    });
+
+    // Users must have unique uids
+    const seen = new Map<string, number[]>();
+    data.users.forEach((user, idx) => {
+      const idxs = seen.get(user.uid) ?? [];
+      idxs.push(idx);
+      seen.set(user.uid, idxs);
+    });
+    for (const idxs of seen.values()) {
+      if (idxs.length < 2) continue;
+      idxs.forEach((idx) => {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Must be unique',
+          path: ['users', idx, 'uid'],
+          input: data.users[idx].uid,
+        });
+      });
+    }
+  });
+
+/** A single user update for the `updateUserInfo` Firebase Function */
+export type UpdateUserInfoUser = z.infer<typeof UpdateUserInfoUserSchema>;
+
+/** Parameters type for `updateUserInfo` Firebase Function */
+export type UpdateUserInfoParams = z.infer<typeof UpdateUserInfoParamsSchema>;
+
+/** Result type for `updateUserInfo` Firebase Function */
+export type UpdateUserInfoResult = {
+  status: string;
+  message: string;
+  data: { uid: string }[];
+};

--- a/src/firebase-functions/update-user-info.ts
+++ b/src/firebase-functions/update-user-info.ts
@@ -1,5 +1,13 @@
 import * as z from 'zod';
 import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
+
+/** The editable fields on a user, excluding the `uid` identifier. */
+const EDITABLE_FIELDS = ['archived', 'disabled'] as const;
 
 /**
  * A single user update accepted by the `updateUserInfo` Firebase Function.
@@ -14,10 +22,7 @@ export const UserInfoSchema = z.object({
   disabled: z.boolean().optional(),
 });
 
-/** The editable fields on a user, excluding the `uid` identifier */
-const EDITABLE_FIELDS = ['archived', 'disabled'] as const;
-
-/** Parameters schema for `updateUserInfo` Firebase Function */
+/** Parameters schema for `updateUserInfo` Firebase Function. */
 export const UpdateUserInfoParamsSchema = z
   .object({
     users: z.array(UserInfoSchema),
@@ -69,12 +74,22 @@ export const UpdateUserInfoParamsSchema = z
     }
   });
 
-/** Parameters type for `updateUserInfo` Firebase Function */
+/** Inferred type of {@link UpdateUserInfoParamsSchema}. */
 export type UpdateUserInfoParams = z.infer<typeof UpdateUserInfoParamsSchema>;
 
-/** Result type for `updateUserInfo` Firebase Function */
+/** Result type for `updateUserInfo` Firebase Function. */
 export type UpdateUserInfoResult = {
   status: string;
   message: string;
   data: { uid: string }[];
 };
+
+/** Error schema for `updateUserInfo` Firebase Function. */
+export const UpdateUserInfoErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link UpdateUserInfoErrorSchema}. */
+export type UpdateUserInfoError = z.infer<typeof UpdateUserInfoErrorSchema>;

--- a/src/firebase-functions/update-user-info.ts
+++ b/src/firebase-functions/update-user-info.ts
@@ -8,7 +8,7 @@ import { NonEmptyStringSchema } from '../shared/non-empty-string';
  * document (i.e., not relationships to other entities such as orgs). Add new
  * optional fields here as more such properties become editable.
  */
-export const UpdateUserInfoUserSchema = z.object({
+export const UserInfoSchema = z.object({
   uid: NonEmptyStringSchema,
   archived: z.boolean().optional(),
   disabled: z.boolean().optional(),
@@ -20,7 +20,7 @@ const EDITABLE_FIELDS = ['archived', 'disabled'] as const;
 /** Parameters schema for `updateUserInfo` Firebase Function */
 export const UpdateUserInfoParamsSchema = z
   .object({
-    users: z.array(UpdateUserInfoUserSchema),
+    users: z.array(UserInfoSchema),
   })
   .superRefine((data, ctx) => {
     // Users array must be non-empty
@@ -68,9 +68,6 @@ export const UpdateUserInfoParamsSchema = z
       });
     }
   });
-
-/** A single user update for the `updateUserInfo` Firebase Function */
-export type UpdateUserInfoUser = z.infer<typeof UpdateUserInfoUserSchema>;
 
 /** Parameters type for `updateUserInfo` Firebase Function */
 export type UpdateUserInfoParams = z.infer<typeof UpdateUserInfoParamsSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,10 @@ import {
   GetSyncStatusParamsSchema,
 } from './firebase-functions/get-sync-status';
 import { ListUsersParamsSchema } from './firebase-functions/list-users';
-import { UpdateUserInfoParamsSchema } from './firebase-functions/update-user-info';
+import {
+  UpdateUserInfoErrorSchema,
+  UpdateUserInfoParamsSchema,
+} from './firebase-functions/update-user-info';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -561,6 +564,7 @@ export {
   SchoolSchema,
   StatSchema,
   TimestampSchema,
+  UpdateUserInfoErrorSchema,
   UpdateUserInfoParamsSchema,
   UserClaimsSchema,
   UserCsvSchema,
@@ -643,6 +647,7 @@ export type SchoolType = z.infer<typeof SchoolSchema>;
 export type StatType = z.infer<typeof StatSchema>;
 export type TimestampType = z.infer<typeof TimestampSchema>;
 export type {
+  UpdateUserInfoError,
   UpdateUserInfoParams,
   UpdateUserInfoResult,
 } from './firebase-functions/update-user-info';

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,7 @@ import {
 import { GetSiteOverviewParamsSchema } from './firebase-functions/get-site-overview';
 import { GetSyncStatusParamsSchema } from './firebase-functions/get-sync-status';
 import { ListUsersParamsSchema } from './firebase-functions/list-users';
-import {
-  UpdateUserInfoParamsSchema,
-  UpdateUserInfoUserSchema,
-} from './firebase-functions/update-user-info';
+import { UpdateUserInfoParamsSchema } from './firebase-functions/update-user-info';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -549,7 +546,6 @@ export {
   StatSchema,
   TimestampSchema,
   UpdateUserInfoParamsSchema,
-  UpdateUserInfoUserSchema,
   UserClaimsSchema,
   UserCsvSchema,
   UserLegalSchema,
@@ -614,7 +610,6 @@ export type LinkUsersCsvType = z.infer<typeof LinkUsersCsvSchema>;
 export type {
   ListUsersParams,
   ListUsersResult,
-  ListUsersUser,
 } from './firebase-functions/list-users';
 export type LocationType = z.infer<typeof LocationSchema>;
 export type OrgAssociationMapType = z.infer<typeof OrgAssociationMapSchema>;
@@ -627,7 +622,6 @@ export type TimestampType = z.infer<typeof TimestampSchema>;
 export type {
   UpdateUserInfoParams,
   UpdateUserInfoResult,
-  UpdateUserInfoUser,
 } from './firebase-functions/update-user-info';
 export type UserClaimsType = z.infer<typeof UserClaimsSchema>;
 export type UserCsvType = z.infer<typeof UserCsvSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ import {
   GetSyncStatusErrorSchema,
   GetSyncStatusParamsSchema,
 } from './firebase-functions/get-sync-status';
-import { ListUsersParamsSchema } from './firebase-functions/list-users';
+import {
+  ListUsersErrorSchema,
+  ListUsersParamsSchema,
+} from './firebase-functions/list-users';
 import {
   UpdateUserInfoErrorSchema,
   UpdateUserInfoParamsSchema,
@@ -550,6 +553,7 @@ export {
   LegalInfoSchema,
   LegalSchema,
   LinkUsersCsvSchema,
+  ListUsersErrorSchema,
   ListUsersParamsSchema,
   LocationSchema,
   locationDocId,
@@ -631,6 +635,7 @@ export type LegalType = z.infer<typeof LegalSchema>;
 /** @deprecated */
 export type LinkUsersCsvType = z.infer<typeof LinkUsersCsvSchema>;
 export type {
+  ListUsersError,
   ListUsersParams,
   ListUsersResult,
 } from './firebase-functions/list-users';

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ import {
 } from './firebase-functions/create-users';
 import { GetSiteOverviewParamsSchema } from './firebase-functions/get-site-overview';
 import { GetSyncStatusParamsSchema } from './firebase-functions/get-sync-status';
+import { ListUsersParamsSchema } from './firebase-functions/list-users';
+import {
+  UpdateUserInfoParamsSchema,
+  UpdateUserInfoUserSchema,
+} from './firebase-functions/update-user-info';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -446,6 +451,7 @@ const UserSchema = z.object({
   archived: z.boolean(),
   classes: OrgAssociationMapSchema,
   createdAt: TimestampSchema,
+  disabled: z.boolean(),
   displayName: z.string(),
   districts: OrgAssociationMapSchema,
   email: z.string(),
@@ -528,6 +534,7 @@ export {
   LegalInfoSchema,
   LegalSchema,
   LinkUsersCsvSchema,
+  ListUsersParamsSchema,
   LocationSchema,
   locationDocId,
   makeCustomIssue,
@@ -541,6 +548,8 @@ export {
   SchoolSchema,
   StatSchema,
   TimestampSchema,
+  UpdateUserInfoParamsSchema,
+  UpdateUserInfoUserSchema,
   UserClaimsSchema,
   UserCsvSchema,
   UserLegalSchema,
@@ -602,6 +611,11 @@ export type LegalInfoType = z.infer<typeof LegalInfoSchema>;
 export type LegalType = z.infer<typeof LegalSchema>;
 /** @deprecated */
 export type LinkUsersCsvType = z.infer<typeof LinkUsersCsvSchema>;
+export type {
+  ListUsersParams,
+  ListUsersResult,
+  ListUsersUser,
+} from './firebase-functions/list-users';
 export type LocationType = z.infer<typeof LocationSchema>;
 export type OrgAssociationMapType = z.infer<typeof OrgAssociationMapSchema>;
 export type OrgRefMapType = z.infer<typeof OrgRefMapSchema>;
@@ -610,6 +624,11 @@ export type ReadOrgType = z.infer<typeof ReadOrgSchema>;
 export type SchoolType = z.infer<typeof SchoolSchema>;
 export type StatType = z.infer<typeof StatSchema>;
 export type TimestampType = z.infer<typeof TimestampSchema>;
+export type {
+  UpdateUserInfoParams,
+  UpdateUserInfoResult,
+  UpdateUserInfoUser,
+} from './firebase-functions/update-user-info';
 export type UserClaimsType = z.infer<typeof UserClaimsSchema>;
 export type UserCsvType = z.infer<typeof UserCsvSchema>;
 export type UserLegalType = z.infer<typeof UserLegalSchema>;


### PR DESCRIPTION
## Add Zod contracts for listUsers and updateUserInfo; add `disabled` to UserSchema

Defines schemas/types for two new Firebase functions and adds the missing
`disabled` field to the user document schema. Contracts only — no backend/
frontend wiring. Note that the /listusers route currently uses an axios query so this will also require a new function.

### Changes
- **`listUsers`** (`list-users.ts`): `ListUsersParamsSchema` (`orgType`, `orgId`,
  optional `page`/`pageLimit`/`restrictToActiveUsers`/`restrictToEnabledUsers`)
  plus `ListUsersResult`. Returned users include `id, username, email, userType,
  archived, disabled`.
- **`updateUserInfo`** (`update-user-info.ts`): bulk-capable contract for
  primitive, user-doc-only fields — `{ users: { uid, archived?, disabled? }[] }`.
  Validates a non-empty array, unique `uid`s, and at least one field per user.
  Named to avoid colliding with the existing `editUsers` function (though this is not in use and may be removed; ROAR legacy).
- **`UserSchema`**: added `disabled: z.boolean()` (it already had `archived`).
- Exported all new schemas/types from `index.ts`.
### Notes
- `active` = `archived == false`; `enabled` = `disabled == false`.
- Additive except for `disabled` on `UserSchema`; that schema is not consumed by
  the backend or dashboard, and both pin a fixed levante-zod version.
### Test plan
- `npm test` (added coverage for both schemas), `tsc`, `biome check`, and
  `npm run build` (attw + publint) all pass.