### PR TITLE
Fix: Support CJS consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Previously the consumer `@levante-framework/firekit` only imported types from this package. Now it imports functional code. Because `@levante-framework/firekit` is a CJS module, it currently fails to import this ES module.

- Add `exports.default` to support CJS consumers