### PR TITLE
Add error schema for getSiteOverview

### DIFF
--- a/src/firebase-functions/create-users.test.ts
+++ b/src/firebase-functions/create-users.test.ts
@@ -882,65 +882,15 @@ describe('CreateUsersErrorSchema', () => {
     });
   });
 
-  describe('permission-denied', () => {
-    const $code = 'permission-denied';
-    const $message = 'Permission denied';
-
-    it('accepts bare functions/permission-denied', () => {
-      const err = new FunctionsError($code, $message);
-      const result = CreateUsersErrorSchema.parse(err);
-      expect(result).toEqual({
-        name: 'FirebaseError',
-        code: `functions/${$code}`,
-        message: $message,
-      });
+  describe('common error codes', () => {
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => CreateUsersErrorSchema.parse(err)).not.toThrow();
     });
 
-    it('rejects functions/permission-denied/foo', () => {
-      const $details = {
-        code: 'foo',
-      };
-      const err = new FunctionsError($code, $message, $details);
-      const result = CreateUsersErrorSchema.safeParse(err);
-      expect(result.success).toBe(false);
-      expect(result.error?.issues.length).toBe(1);
-      expect(result.error?.issues[0]).toEqual({
-        expected: 'undefined',
-        code: 'invalid_type',
-        path: ['details'],
-        message: 'Invalid input: expected undefined, received object',
-      });
-    });
-  });
-
-  describe('unauthenticated', () => {
-    const $code = 'unauthenticated';
-    const $message = 'Unauthenticated';
-
-    it('accepts bare functions/unauthenticated', () => {
-      const err = new FunctionsError($code, $message);
-      const result = CreateUsersErrorSchema.parse(err);
-      expect(result).toEqual({
-        name: 'FirebaseError',
-        code: `functions/${$code}`,
-        message: $message,
-      });
-    });
-
-    it('rejects functions/unauthenticated/foo', () => {
-      const $details = {
-        code: 'foo',
-      };
-      const err = new FunctionsError($code, $message, $details);
-      const result = CreateUsersErrorSchema.safeParse(err);
-      expect(result.success).toBe(false);
-      expect(result.error?.issues.length).toBe(1);
-      expect(result.error?.issues[0]).toEqual({
-        expected: 'undefined',
-        code: 'invalid_type',
-        path: ['details'],
-        message: 'Invalid input: expected undefined, received object',
-      });
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => CreateUsersErrorSchema.parse(err)).not.toThrow();
     });
   });
 });

--- a/src/firebase-functions/create-users.ts
+++ b/src/firebase-functions/create-users.ts
@@ -1,7 +1,11 @@
 import * as z from 'zod';
 import { CHILD_YEAR_MAX, CHILD_YEAR_MIN } from '../csv/user-csv';
 import { NonEmptyStringSchema } from '../shared/non-empty-string';
-import { FunctionsErrorSchema } from './error';
+import {
+  FunctionsErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
 
 /** @deprecated */
 export const CreateUserSchema = z.object({
@@ -187,14 +191,8 @@ export const CreateUsersErrorSchema = z.discriminatedUnion('code', [
       }),
     }),
   }),
-  FunctionsErrorSchema.extend({
-    code: z.literal('functions/permission-denied'),
-    details: z.undefined(),
-  }),
-  FunctionsErrorSchema.extend({
-    code: z.literal('functions/unauthenticated'),
-    details: z.undefined(),
-  }),
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
 ]);
 
 /** Inferred type of {@link CreateUsersErrorSchema}. */

--- a/src/firebase-functions/error.test.ts
+++ b/src/firebase-functions/error.test.ts
@@ -1,7 +1,13 @@
 import { FirebaseError } from 'firebase/app';
 import { FunctionsError } from 'firebase/functions';
 import { describe, expect, it } from 'vitest';
-import { FirebaseErrorSchema, FunctionsErrorSchema } from './error';
+import {
+  FirebaseErrorSchema,
+  FunctionsErrorSchema,
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
 
 const $name = 'FirebaseError';
 const $code = 'internal';
@@ -133,6 +139,125 @@ describe('FunctionsErrorSchema', () => {
       code: 'invalid_type',
       path: ['code'],
       message: 'Invalid input: expected string, received undefined',
+    });
+  });
+});
+
+describe('InvalidArgumentErrorSchema', () => {
+  const $code = 'invalid-argument';
+  const $message = 'Schema error';
+
+  it('accepts functions/invalid-argument/schema', () => {
+    const $details = {
+      code: 'schema',
+      issues: [
+        { path: 'users[0].firstName', message: 'Required' },
+        { path: 'users[1].grade', message: 'Invalid value' },
+      ],
+    };
+    const err = new FunctionsError($code, $message, $details);
+    const result = InvalidArgumentErrorSchema.parse(err);
+    expect(result).toEqual({
+      name: 'FirebaseError',
+      code: `functions/${$code}`,
+      message: $message,
+      details: $details,
+    });
+  });
+
+  it('rejects bare functions/invalid-argument', () => {
+    const err = new FunctionsError($code, 'Foo error');
+    const result = InvalidArgumentErrorSchema.safeParse(err);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual({
+      expected: 'object',
+      code: 'invalid_type',
+      path: ['details'],
+      message: 'Invalid input: expected object, received undefined',
+    });
+  });
+
+  it('rejects functions/invalid-argument/foo', () => {
+    const err = new FunctionsError($code, 'Foo error', {
+      code: 'foo',
+    });
+    const result = InvalidArgumentErrorSchema.safeParse(err);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual({
+      code: 'invalid_value',
+      values: ['schema'],
+      path: ['details', 'code'],
+      message: 'Invalid input: expected "schema"',
+    });
+    expect(result.error?.issues[1]).toEqual({
+      expected: 'array',
+      code: 'invalid_type',
+      path: ['details', 'issues'],
+      message: 'Invalid input: expected array, received undefined',
+    });
+  });
+});
+
+describe('PermissionDeniedErrorSchema', () => {
+  const $code = 'permission-denied';
+  const $message = 'Permission denied';
+
+  it('accepts bare functions/permission-denied', () => {
+    const err = new FunctionsError($code, $message);
+    const result = PermissionDeniedErrorSchema.parse(err);
+    expect(result).toEqual({
+      name: 'FirebaseError',
+      code: `functions/${$code}`,
+      message: $message,
+    });
+  });
+
+  it('rejects functions/permission-denied/foo', () => {
+    const $details = {
+      code: 'foo',
+    };
+    const err = new FunctionsError($code, $message, $details);
+    const result = PermissionDeniedErrorSchema.safeParse(err);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual({
+      expected: 'undefined',
+      code: 'invalid_type',
+      path: ['details'],
+      message: 'Invalid input: expected undefined, received object',
+    });
+  });
+});
+
+describe('UnauthenticatedErrorSchema', () => {
+  const $code = 'unauthenticated';
+  const $message = 'Unauthenticated';
+
+  it('accepts bare functions/unauthenticated', () => {
+    const err = new FunctionsError($code, $message);
+    const result = UnauthenticatedErrorSchema.parse(err);
+    expect(result).toEqual({
+      name: 'FirebaseError',
+      code: `functions/${$code}`,
+      message: $message,
+    });
+  });
+
+  it('rejects functions/unauthenticated/foo', () => {
+    const $details = {
+      code: 'foo',
+    };
+    const err = new FunctionsError($code, $message, $details);
+    const result = UnauthenticatedErrorSchema.safeParse(err);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual({
+      expected: 'undefined',
+      code: 'invalid_type',
+      path: ['details'],
+      message: 'Invalid input: expected undefined, received object',
     });
   });
 });

--- a/src/firebase-functions/error.ts
+++ b/src/firebase-functions/error.ts
@@ -30,3 +30,24 @@ export const FunctionsErrorSchema = z.object({
  * NB: Named `ParsedFunctionsError` to avoid conflict with `FunctionsError` from `firebase/functions`.
  */
 export type ParsedFunctionsError = z.infer<typeof FunctionsErrorSchema>;
+
+/** Default schema for `functions/invalid-argument` errors - i.e., only `schema` sub-case. */
+export const InvalidArgumentErrorSchema = FunctionsErrorSchema.extend({
+  code: z.literal('functions/invalid-argument'),
+  details: z.object({
+    code: z.literal('schema'),
+    issues: z.array(z.object({ path: z.string(), message: z.string() })),
+  }),
+});
+
+/** Default schema for `functions/permission-denied` errors. */
+export const PermissionDeniedErrorSchema = FunctionsErrorSchema.extend({
+  code: z.literal('functions/permission-denied'),
+  details: z.undefined(),
+});
+
+/** Default schema for `functions/unauthenticated` errors. */
+export const UnauthenticatedErrorSchema = FunctionsErrorSchema.extend({
+  code: z.literal('functions/unauthenticated'),
+  details: z.undefined(),
+});

--- a/src/firebase-functions/get-site-overview.test.ts
+++ b/src/firebase-functions/get-site-overview.test.ts
@@ -1,5 +1,9 @@
+import { FunctionsError } from 'firebase/functions';
 import { describe, expect, it } from 'vitest';
-import { GetSiteOverviewParamsSchema } from './get-site-overview';
+import {
+  GetSiteOverviewErrorSchema,
+  GetSiteOverviewParamsSchema,
+} from './get-site-overview';
 
 describe('GetSiteOverviewParamsSchema', () => {
   it('accepts valid props', () => {
@@ -28,5 +32,27 @@ describe('GetSiteOverviewParamsSchema', () => {
         path: ['siteId'],
       },
     ]);
+  });
+});
+
+describe('GetSiteOverviewErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'users[0].firstName', message: 'Required' }],
+      });
+      expect(() => GetSiteOverviewErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => GetSiteOverviewErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => GetSiteOverviewErrorSchema.parse(err)).not.toThrow();
+    });
   });
 });

--- a/src/firebase-functions/get-site-overview.ts
+++ b/src/firebase-functions/get-site-overview.ts
@@ -1,15 +1,20 @@
 import * as z from 'zod';
 import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
 
-/** Parameters schema for `getSiteOverview` Firebase Function */
+/** Parameters schema for `getSiteOverview` Firebase Function. */
 export const GetSiteOverviewParamsSchema = z.object({
   siteId: NonEmptyStringSchema,
 });
 
-/** Parameters type for `getSiteOverview` Firebase Function */
+/** Inferred type of {@link GetSiteOverviewParamsSchema}. */
 export type GetSiteOverviewParams = z.infer<typeof GetSiteOverviewParamsSchema>;
 
-/** Result type for `getSiteOverview` Firebase Function */
+/** Result type for `getSiteOverview` Firebase Function. */
 export type GetSiteOverviewResult = {
   counts: {
     users: {
@@ -27,3 +32,13 @@ export type GetSiteOverviewResult = {
   classes: { id: string; name: string; schoolId: string }[];
   cohorts: { id: string; name: string }[];
 };
+
+/** Error schema for `getSiteOverview` Firebase Function. */
+export const GetSiteOverviewErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link GetSiteOverviewErrorSchema}. */
+export type GetSiteOverviewError = z.infer<typeof GetSiteOverviewErrorSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,10 @@ import {
   FirebaseErrorSchema,
   FunctionsErrorSchema,
 } from './firebase-functions/error';
-import { GetSiteOverviewParamsSchema } from './firebase-functions/get-site-overview';
+import {
+  GetSiteOverviewErrorSchema,
+  GetSiteOverviewParamsSchema,
+} from './firebase-functions/get-site-overview';
 import { GetSyncStatusParamsSchema } from './firebase-functions/get-sync-status';
 import { makeCustomIssue } from './util/issues';
 
@@ -528,6 +531,7 @@ export {
   DistrictSchema,
   FirebaseErrorSchema,
   FunctionsErrorSchema,
+  GetSiteOverviewErrorSchema,
   GetSiteOverviewParamsSchema,
   GetSyncStatusParamsSchema,
   GroupSchema,
@@ -598,6 +602,7 @@ export type CsvHeadersType = z.infer<typeof CsvHeadersSchema>;
 export type DistrictType = z.infer<typeof DistrictSchema>;
 export type H3CellType = z.infer<typeof H3CellSchema>;
 export type {
+  GetSiteOverviewError,
   GetSiteOverviewParams,
   GetSiteOverviewResult,
 } from './firebase-functions/get-site-overview';


### PR DESCRIPTION
- `src/index.ts`
  - Add package exports `GetSiteOverviewErrorSchema`, `GetSiteOverviewError` type
- `src/firebase-functions/error.ts`, `src/firebase-functions/error.test.ts`
  - Add `InvalidArgumentErrorSchema`, `PermissionDeniedErrorSchema`, `UnauthenticatedErrorSchema` for common error codes
- `src/firebase-functions/get-site-overview.ts`, `src/firebase-functions/get-site-overview.test.ts`
  - Add `GetSiteOverviewErrorSchema`, `GetSiteOverviewError` type
  - Tweak docstrings
- `src/firebase-functions/create-users.ts`, `src/firebase-functions/create-users.test.ts`
  - Refactor to use `PermissionDeniedErrorSchema`, `UnauthenticatedErrorSchema`