### PR TITLE
Add loadFormDefinitions and saveOrgInformation schemas

### DIFF
--- a/src/firebase-functions/load-form-definitions.test.ts
+++ b/src/firebase-functions/load-form-definitions.test.ts
@@ -1,0 +1,114 @@
+import { FunctionsError } from 'firebase/functions';
+import { describe, expect, it } from 'vitest';
+import {
+  LoadFormDefinitionsErrorSchema,
+  LoadFormDefinitionsParamsSchema,
+} from './load-form-definitions';
+
+describe('LoadFormDefinitionsParamsSchema', () => {
+  it('accepts valid site props', () => {
+    expect(
+      LoadFormDefinitionsParamsSchema.parse({
+        orgType: 'site',
+        orgId: 'district-1',
+      }),
+    ).toEqual({
+      orgType: 'site',
+      orgId: 'district-1',
+    });
+  });
+
+  it('accepts valid school props', () => {
+    expect(
+      LoadFormDefinitionsParamsSchema.parse({
+        orgType: 'school',
+        orgId: 'school-1',
+      }),
+    ).toEqual({
+      orgType: 'school',
+      orgId: 'school-1',
+    });
+  });
+
+  it('trims orgId whitespace', () => {
+    expect(
+      LoadFormDefinitionsParamsSchema.parse({
+        orgType: 'site',
+        orgId: '  district-1  ',
+      }),
+    ).toEqual({
+      orgType: 'site',
+      orgId: 'district-1',
+    });
+  });
+
+  it('strips unexpected props', () => {
+    const result = LoadFormDefinitionsParamsSchema.parse({
+      orgType: 'site',
+      orgId: 'district-1',
+      unexpected: 'bar',
+    });
+    expect(result).toEqual({
+      orgType: 'site',
+      orgId: 'district-1',
+    });
+  });
+
+  it('rejects missing orgType', () => {
+    const result = LoadFormDefinitionsParamsSchema.safeParse({
+      orgId: 'district-1',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgType']);
+  });
+
+  it('rejects invalid orgType', () => {
+    const result = LoadFormDefinitionsParamsSchema.safeParse({
+      orgType: 'district',
+      orgId: 'district-1',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgType']);
+  });
+
+  it('rejects empty orgId', () => {
+    const result = LoadFormDefinitionsParamsSchema.safeParse({
+      orgType: 'site',
+      orgId: '   ',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgId']);
+  });
+
+  it('rejects missing orgId', () => {
+    const result = LoadFormDefinitionsParamsSchema.safeParse({
+      orgType: 'site',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Invalid input: expected string, received undefined',
+        path: ['orgId'],
+      },
+    ]);
+  });
+});
+
+describe('LoadFormDefinitionsErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'orgType', message: 'Invalid option' }],
+      });
+      expect(() => LoadFormDefinitionsErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => LoadFormDefinitionsErrorSchema.parse(err)).not.toThrow();
+    });
+  });
+});

--- a/src/firebase-functions/load-form-definitions.ts
+++ b/src/firebase-functions/load-form-definitions.ts
@@ -49,7 +49,7 @@ export type LoadFormDefinitionsResult = {
   fullFields: InformationFormField[];
   orgType: 'site' | 'school';
   orgId: string;
-  /** Previously saved answers for this org; empty until save (#110) lands. */
+  /** Previously saved answers for this org. Empty in v1. */
   savedResponses: unknown[];
 };
 

--- a/src/firebase-functions/load-form-definitions.ts
+++ b/src/firebase-functions/load-form-definitions.ts
@@ -1,0 +1,65 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  InvalidArgumentErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
+
+/** Parameters schema for `loadFormDefinitions` Firebase Function. */
+export const LoadFormDefinitionsParamsSchema = z.object({
+  orgType: z.enum(['site', 'school']),
+  orgId: NonEmptyStringSchema,
+});
+
+/** Inferred type of {@link LoadFormDefinitionsParamsSchema}. */
+export type LoadFormDefinitionsParams = z.infer<
+  typeof LoadFormDefinitionsParamsSchema
+>;
+
+/** A section heading within an information form definition. */
+export type FormSectionInfo = {
+  sectionId: string;
+  title: string;
+  description: string;
+};
+
+/** A single field within an information form definition. */
+export type InformationFormField = {
+  itemId: string;
+  variableName: string;
+  kind: 'text' | 'number' | 'single-select' | 'multi-select';
+  required: boolean;
+  sectionId: string;
+  questionText: string;
+  options?: { value: string; label: string }[];
+  displayLogic?: { field: string; includes: string };
+  infoExample?: string;
+  notes?: string;
+};
+
+/** Result type for `loadFormDefinitions` Firebase Function. */
+export type LoadFormDefinitionsResult = {
+  formId: string;
+  versionId: string;
+  versionNumber: number;
+  formDescription: string;
+  fieldsDescription: Record<string, string>;
+  generalPrompt: string;
+  sectionInfo: FormSectionInfo[];
+  fullFields: InformationFormField[];
+  orgType: 'site' | 'school';
+  orgId: string;
+  /** Previously saved answers for this org; empty until save (#110) lands. */
+  savedResponses: unknown[];
+};
+
+/** Error schema for `loadFormDefinitions` Firebase Function. */
+export const LoadFormDefinitionsErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link LoadFormDefinitionsErrorSchema}. */
+export type LoadFormDefinitionsError = z.infer<
+  typeof LoadFormDefinitionsErrorSchema
+>;

--- a/src/firebase-functions/save-org-information.test.ts
+++ b/src/firebase-functions/save-org-information.test.ts
@@ -141,6 +141,11 @@ describe('SaveOrgInformationErrorSchema', () => {
       expect(() => SaveOrgInformationErrorSchema.parse(err)).not.toThrow();
     });
 
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => SaveOrgInformationErrorSchema.parse(err)).not.toThrow();
+    });
+
     it('accepts functions/unauthenticated', () => {
       const err = new FunctionsError('unauthenticated', 'Unauthenticated');
       expect(() => SaveOrgInformationErrorSchema.parse(err)).not.toThrow();

--- a/src/firebase-functions/save-org-information.test.ts
+++ b/src/firebase-functions/save-org-information.test.ts
@@ -1,0 +1,149 @@
+import { FunctionsError } from 'firebase/functions';
+import { describe, expect, it } from 'vitest';
+import {
+  SaveOrgInformationErrorSchema,
+  SaveOrgInformationParamsSchema,
+} from './save-org-information';
+
+const validParams = {
+  orgType: 'site' as const,
+  orgId: 'district-1',
+  formVersion: 'version-1',
+  responses: {
+    sampleApproach: ['other'],
+    sampleApproachOther: 'word of mouth',
+  },
+  status: 'draft' as const,
+};
+
+describe('SaveOrgInformationParamsSchema', () => {
+  it('accepts valid site draft props', () => {
+    expect(SaveOrgInformationParamsSchema.parse(validParams)).toEqual(
+      validParams,
+    );
+  });
+
+  it('accepts valid school submitted props', () => {
+    expect(
+      SaveOrgInformationParamsSchema.parse({
+        orgType: 'school',
+        orgId: 'school-1',
+        formVersion: 'version-2',
+        responses: { numTeachers: '12' },
+        status: 'submitted',
+      }),
+    ).toEqual({
+      orgType: 'school',
+      orgId: 'school-1',
+      formVersion: 'version-2',
+      responses: { numTeachers: '12' },
+      status: 'submitted',
+    });
+  });
+
+  it('accepts empty responses object', () => {
+    expect(
+      SaveOrgInformationParamsSchema.parse({
+        ...validParams,
+        responses: {},
+      }),
+    ).toEqual({
+      ...validParams,
+      responses: {},
+    });
+  });
+
+  it('trims orgId and formVersion whitespace', () => {
+    expect(
+      SaveOrgInformationParamsSchema.parse({
+        ...validParams,
+        orgId: '  district-1  ',
+        formVersion: '  version-1  ',
+      }),
+    ).toEqual(validParams);
+  });
+
+  it('strips unexpected props', () => {
+    const result = SaveOrgInformationParamsSchema.parse({
+      ...validParams,
+      unexpected: 'bar',
+    });
+    expect(result).toEqual(validParams);
+  });
+
+  it('rejects missing orgType', () => {
+    const { orgType: _, ...rest } = validParams;
+    const result = SaveOrgInformationParamsSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgType']);
+  });
+
+  it('rejects invalid orgType', () => {
+    const result = SaveOrgInformationParamsSchema.safeParse({
+      ...validParams,
+      orgType: 'district',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgType']);
+  });
+
+  it('rejects empty orgId', () => {
+    const result = SaveOrgInformationParamsSchema.safeParse({
+      ...validParams,
+      orgId: '   ',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['orgId']);
+  });
+
+  it('rejects empty formVersion', () => {
+    const result = SaveOrgInformationParamsSchema.safeParse({
+      ...validParams,
+      formVersion: '   ',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['formVersion']);
+  });
+
+  it('rejects invalid status', () => {
+    const result = SaveOrgInformationParamsSchema.safeParse({
+      ...validParams,
+      status: 'complete',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['status']);
+  });
+
+  it('rejects responses when not an object', () => {
+    const result = SaveOrgInformationParamsSchema.safeParse({
+      ...validParams,
+      responses: ['sampleApproach'],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['responses']);
+  });
+
+  it('rejects missing responses', () => {
+    const { responses: _, ...rest } = validParams;
+    const result = SaveOrgInformationParamsSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['responses']);
+  });
+});
+
+describe('SaveOrgInformationErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'orgType', message: 'Invalid option' }],
+      });
+      expect(() => SaveOrgInformationErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => SaveOrgInformationErrorSchema.parse(err)).not.toThrow();
+    });
+  });
+});

--- a/src/firebase-functions/save-org-information.ts
+++ b/src/firebase-functions/save-org-information.ts
@@ -1,0 +1,52 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  InvalidArgumentErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
+
+/**
+ * Parameters schema for `saveOrgInformation` Firebase Function.
+ *
+ * v1 validates the request envelope only. Response field values are not checked
+ * against SiteInformation / SchoolInformation (partial page saves are allowed).
+ */
+export const SaveOrgInformationParamsSchema = z.object({
+  orgType: z.enum(['site', 'school']),
+  orgId: NonEmptyStringSchema,
+  /** Document ID of `formDefinitions/.../versions/{versionId}`. */
+  formVersion: NonEmptyStringSchema,
+  /**
+   * Partial answers keyed by form `variableName`.
+   * Values are untyped in v1 (string | number | string[] | …).
+   */
+  responses: z.record(z.string(), z.unknown()),
+  /** `draft` for Next/Save; `submitted` for Submit. Pending schema confirm. */
+  status: z.enum(['draft', 'submitted']),
+});
+
+/** Inferred type of {@link SaveOrgInformationParamsSchema}. */
+export type SaveOrgInformationParams = z.infer<
+  typeof SaveOrgInformationParamsSchema
+>;
+
+/** Result type for `saveOrgInformation` Firebase Function. */
+export type SaveOrgInformationResult = {
+  orgType: 'site' | 'school';
+  orgId: string;
+  formVersion: string;
+  status: 'draft' | 'submitted';
+  /** Firestore path that was merged, e.g. `districts/{id}/siteInformation/response`. */
+  path: string;
+};
+
+/** Error schema for `saveOrgInformation` Firebase Function. */
+export const SaveOrgInformationErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link SaveOrgInformationErrorSchema}. */
+export type SaveOrgInformationError = z.infer<
+  typeof SaveOrgInformationErrorSchema
+>;

--- a/src/firebase-functions/save-org-information.ts
+++ b/src/firebase-functions/save-org-information.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { NonEmptyStringSchema } from '../shared/non-empty-string';
 import {
   InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
   UnauthenticatedErrorSchema,
 } from './error';
 
@@ -43,6 +44,7 @@ export type SaveOrgInformationResult = {
 /** Error schema for `saveOrgInformation` Firebase Function. */
 export const SaveOrgInformationErrorSchema = z.discriminatedUnion('code', [
   InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
   UnauthenticatedErrorSchema,
 ]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ import {
   GetSyncStatusErrorSchema,
   GetSyncStatusParamsSchema,
 } from './firebase-functions/get-sync-status';
+import {
+  LoadFormDefinitionsErrorSchema,
+  LoadFormDefinitionsParamsSchema,
+} from './firebase-functions/load-form-definitions';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -544,6 +548,8 @@ export {
   LegalInfoSchema,
   LegalSchema,
   LinkUsersCsvSchema,
+  LoadFormDefinitionsErrorSchema,
+  LoadFormDefinitionsParamsSchema,
   LocationSchema,
   locationDocId,
   makeCustomIssue,
@@ -615,6 +621,13 @@ export type {
   GetSyncStatusParams,
   GetSyncStatusResult,
 } from './firebase-functions/get-sync-status';
+export type {
+  FormSectionInfo,
+  InformationFormField,
+  LoadFormDefinitionsError,
+  LoadFormDefinitionsParams,
+  LoadFormDefinitionsResult,
+} from './firebase-functions/load-form-definitions';
 export type GroupType = z.infer<typeof GroupSchema>;
 export type LatLonSourceType = z.infer<typeof LatLonSourceSchema>;
 export type LegalInfoType = z.infer<typeof LegalInfoSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ import {
   LoadFormDefinitionsErrorSchema,
   LoadFormDefinitionsParamsSchema,
 } from './firebase-functions/load-form-definitions';
+import {
+  SaveOrgInformationErrorSchema,
+  SaveOrgInformationParamsSchema,
+} from './firebase-functions/save-org-information';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -560,6 +564,8 @@ export {
   OrgSchema,
   parseCommaSeparated,
   ReadOrgSchema,
+  SaveOrgInformationErrorSchema,
+  SaveOrgInformationParamsSchema,
   SchoolSchema,
   StatSchema,
   TimestampSchema,
@@ -628,6 +634,11 @@ export type {
   LoadFormDefinitionsParams,
   LoadFormDefinitionsResult,
 } from './firebase-functions/load-form-definitions';
+export type {
+  SaveOrgInformationError,
+  SaveOrgInformationParams,
+  SaveOrgInformationResult,
+} from './firebase-functions/save-org-information';
 export type GroupType = z.infer<typeof GroupSchema>;
 export type LatLonSourceType = z.infer<typeof LatLonSourceSchema>;
 export type LegalInfoType = z.infer<typeof LegalInfoSchema>;


### PR DESCRIPTION
## Summary

Schemas for site/school information form callables.

- `loadFormDefinitions`: params / result / error. `savedResponses` is `[]` in v1.
- `saveOrgInformation`: params / result / error. Validates the request shape only (`responses` values are not checked).
- `prepare` script so GitHub branch installs build `dist`.

Used by [functions#118](https://github.com/levante-framework/levante-firebase-functions/pull/118). UI: [levante-dashboard#1015](https://github.com/levante-framework/levante-dashboard/pull/1015).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Test plan

- [x] `npm test`

## Additional Notes

After merge: run Publish workflow (`patch`). Functions currently depends on this GitHub branch until that publishes; then switch to the new npm version before merging the functions PR.