### PR TITLE
fix: don't run publint/attw during the prepare lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@arethetypeswrong/core": "^0.18.5",
         "@biomejs/biome": "2.5.7",
         "@fast-check/vitest": "^0.4.1",
+        "@types/node": "^24.13.3",
         "@vitest/coverage-v8": "^4.1.10",
         "fast-check": "^4.9.0",
         "firebase": "^12.17.1",
@@ -390,6 +391,7 @@
       "integrity": "sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.4",
         "@firebase/logger": "0.5.1",
@@ -462,6 +464,7 @@
       "integrity": "sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.16.0",
         "@firebase/component": "0.7.4",
@@ -479,6 +482,7 @@
       "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.1"
       }
@@ -985,6 +989,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1453,13 +1458,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1468,6 +1473,7 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -2568,9 +2574,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2592,9 +2595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2616,9 +2616,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2640,9 +2637,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2896,6 +2890,7 @@
       "integrity": "sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@publint/pack": "^0.1.6",
         "package-manager-detector": "^1.7.0",
@@ -2982,6 +2977,7 @@
       "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -3310,6 +3306,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3333,9 +3330,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3368,6 +3365,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -3446,6 +3444,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check": "biome check",
     "check:fix": "biome check --write",
     "dev": "tsdown --watch",
-    "prepare": "npm run build",
+    "prepare": "tsdown",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
@@ -44,6 +44,7 @@
     "@arethetypeswrong/core": "^0.18.5",
     "@biomejs/biome": "2.5.7",
     "@fast-check/vitest": "^0.4.1",
+    "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.10",
     "fast-check": "^4.9.0",
     "firebase": "^12.17.1",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'tsdown';
 
+// publint/attw pack the package via `npm pack`; skip that during the `prepare`
+// lifecycle so consumer git-installs get a plain, fast, robust build.
+const validatePackaging = process.env.npm_lifecycle_event !== 'prepare';
+
 export default defineConfig({
-  attw: {
-    profile: 'esm-only',
-  },
+  attw: validatePackaging ? { profile: 'esm-only' } : false,
   platform: 'neutral',
-  publint: true,
+  publint: validatePackaging,
 });


### PR DESCRIPTION
## Summary

When installing this package directly from a GitHub link (rather than the npm registry), the `prepare` script runs `tsdown`, whose `publint`/`attw` validators pack the package via `npm pack`. Running these packaging validators in the consumer install path is unnecessary work and can hard-fail in restricted, offline, or CI environments.

This change scopes the validators to explicit builds only:

- `prepare` now invokes `tsdown` directly so the npm lifecycle event stays `prepare`.
- `tsdown.config.ts` disables `publint`/`attw` when `npm_lifecycle_event === 'prepare'`.
- Add `@types/node` as a direct devDependency (was only transitive), so `process` in the config resolves reliably.

## Behavior

- `npm run build` (used by CI and `publish.yml`) → validators **on**; packaging is still validated before publish.
- `prepare` (consumer git installs) → validators **off**; plain, fast, robust build.

## Test plan

- [x] `npm run build` runs `[attw]` + `[publint]`
- [x] `npm run prepare` builds without the validators
- [x] `npx tsc --noEmit` passes
- [x] `npm run check` (biome) passes