### PR TITLE
feat: getUsersByOrg firebase function schemas

### DIFF
--- a/src/firebase-functions/get-users-by-org.test.ts
+++ b/src/firebase-functions/get-users-by-org.test.ts
@@ -121,6 +121,37 @@ describe('GetUsersByOrgErrorSchema', () => {
     });
   });
 
+  describe('functions/internal', () => {
+    it('accepts a valid org-site-missing error', () => {
+      const err = new FunctionsError('internal', 'Org site missing', {
+        code: 'org-site-missing',
+        orgType: 'school',
+        orgId: 'foo',
+        siteId: 'bar',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('rejects an unknown details code', () => {
+      const err = new FunctionsError('internal', 'Org site missing', {
+        code: 'unknown',
+        orgType: 'school',
+        orgId: 'foo',
+        siteId: 'bar',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
+    });
+
+    it('rejects a missing siteId', () => {
+      const err = new FunctionsError('internal', 'Org site missing', {
+        code: 'org-site-missing',
+        orgType: 'school',
+        orgId: 'foo',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
+    });
+  });
+
   describe('functions/not-found', () => {
     it('accepts a valid org not-found error', () => {
       const err = new FunctionsError('not-found', 'Org not found', {

--- a/src/firebase-functions/get-users-by-org.test.ts
+++ b/src/firebase-functions/get-users-by-org.test.ts
@@ -1,0 +1,164 @@
+import { FunctionsError } from 'firebase/functions';
+import { describe, expect, it } from 'vitest';
+import {
+  GetUsersByOrgErrorSchema,
+  GetUsersByOrgParamsSchema,
+} from './get-users-by-org';
+
+describe('GetUsersByOrgParamsSchema', () => {
+  it('accepts valid props', () => {
+    expect(
+      GetUsersByOrgParamsSchema.parse({ orgType: 'site', orgId: 'foo' }),
+    ).toEqual({ orgType: 'site', orgId: 'foo' });
+  });
+
+  it.each(['site', 'school', 'class', 'cohort'] as const)(
+    'accepts orgType "%s"',
+    (orgType) => {
+      expect(
+        GetUsersByOrgParamsSchema.parse({ orgType, orgId: 'foo' }),
+      ).toEqual({ orgType, orgId: 'foo' });
+    },
+  );
+
+  it('trims orgId', () => {
+    expect(
+      GetUsersByOrgParamsSchema.parse({ orgType: 'site', orgId: '  foo  ' }),
+    ).toEqual({ orgType: 'site', orgId: 'foo' });
+  });
+
+  it('strips unexpected props', () => {
+    const result = GetUsersByOrgParamsSchema.parse({
+      orgType: 'site',
+      orgId: 'foo',
+      unexpected: 'bar',
+      another: 'baz',
+    });
+    expect(result).toEqual({ orgType: 'site', orgId: 'foo' });
+  });
+
+  it('rejects an invalid orgType', () => {
+    const result = GetUsersByOrgParamsSchema.safeParse({
+      orgType: 'district',
+      orgId: 'foo',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'invalid_value',
+        values: ['site', 'school', 'class', 'cohort'],
+        message:
+          'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
+        path: ['orgType'],
+      },
+    ]);
+  });
+
+  it('rejects missing orgType', () => {
+    const result = GetUsersByOrgParamsSchema.safeParse({ orgId: 'foo' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'invalid_value',
+        values: ['site', 'school', 'class', 'cohort'],
+        message:
+          'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
+        path: ['orgType'],
+      },
+    ]);
+  });
+
+  it('rejects missing orgId', () => {
+    const result = GetUsersByOrgParamsSchema.safeParse({ orgType: 'site' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Invalid input: expected string, received undefined',
+        path: ['orgId'],
+      },
+    ]);
+  });
+
+  it('rejects an empty orgId', () => {
+    const result = GetUsersByOrgParamsSchema.safeParse({
+      orgType: 'site',
+      orgId: '   ',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      {
+        code: 'too_small',
+        inclusive: true,
+        message: 'Too small: expected string to have >=1 characters',
+        origin: 'string',
+        minimum: 1,
+        path: ['orgId'],
+      },
+    ]);
+  });
+});
+
+describe('GetUsersByOrgErrorSchema', () => {
+  describe('common error codes', () => {
+    it('accepts functions/invalid-argument/schema', () => {
+      const err = new FunctionsError('invalid-argument', 'Schema error', {
+        code: 'schema',
+        issues: [{ path: 'orgId', message: 'Required' }],
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/permission-denied', () => {
+      const err = new FunctionsError('permission-denied', 'Permission denied');
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it('accepts functions/unauthenticated', () => {
+      const err = new FunctionsError('unauthenticated', 'Unauthenticated');
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+    });
+  });
+
+  describe('functions/not-found', () => {
+    it('accepts a valid org not-found error', () => {
+      const err = new FunctionsError('not-found', 'Org not found', {
+        code: 'org',
+        id: 'foo',
+        type: 'site',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+    });
+
+    it.each(['site', 'school', 'class', 'cohort'] as const)(
+      'accepts org type "%s"',
+      (type) => {
+        const err = new FunctionsError('not-found', 'Org not found', {
+          code: 'org',
+          id: 'foo',
+          type,
+        });
+        expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+      },
+    );
+
+    it('rejects an unknown details code', () => {
+      const err = new FunctionsError('not-found', 'Org not found', {
+        code: 'user',
+        id: 'foo',
+        type: 'site',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
+    });
+
+    it('rejects an invalid org type', () => {
+      const err = new FunctionsError('not-found', 'Org not found', {
+        code: 'org',
+        id: 'foo',
+        type: 'district',
+      });
+      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
+    });
+  });
+});

--- a/src/firebase-functions/get-users-by-org.test.ts
+++ b/src/firebase-functions/get-users-by-org.test.ts
@@ -6,26 +6,14 @@ import {
 } from './get-users-by-org';
 
 describe('GetUsersByOrgParamsSchema', () => {
-  it('accepts valid props', () => {
-    expect(
-      GetUsersByOrgParamsSchema.parse({ orgType: 'site', orgId: 'foo' }),
-    ).toEqual({ orgType: 'site', orgId: 'foo' });
-  });
-
   it.each(['site', 'school', 'class', 'cohort'] as const)(
-    'accepts orgType "%s"',
+    'accepts valid props w/ orgType "%s"',
     (orgType) => {
       expect(
         GetUsersByOrgParamsSchema.parse({ orgType, orgId: 'foo' }),
       ).toEqual({ orgType, orgId: 'foo' });
     },
   );
-
-  it('trims orgId', () => {
-    expect(
-      GetUsersByOrgParamsSchema.parse({ orgType: 'site', orgId: '  foo  ' }),
-    ).toEqual({ orgType: 'site', orgId: 'foo' });
-  });
 
   it('strips unexpected props', () => {
     const result = GetUsersByOrgParamsSchema.parse({
@@ -37,66 +25,70 @@ describe('GetUsersByOrgParamsSchema', () => {
     expect(result).toEqual({ orgType: 'site', orgId: 'foo' });
   });
 
-  it('rejects an invalid orgType', () => {
-    const result = GetUsersByOrgParamsSchema.safeParse({
-      orgType: 'district',
-      orgId: 'foo',
+  describe('orgType', () => {
+    it('rejects an invalid orgType', () => {
+      const result = GetUsersByOrgParamsSchema.safeParse({
+        orgType: 'district',
+        orgId: 'foo',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'invalid_value',
+          values: ['site', 'school', 'class', 'cohort'],
+          message:
+            'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
+          path: ['orgType'],
+        },
+      ]);
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.issues).toEqual([
-      {
-        code: 'invalid_value',
-        values: ['site', 'school', 'class', 'cohort'],
-        message:
-          'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
-        path: ['orgType'],
-      },
-    ]);
-  });
 
-  it('rejects missing orgType', () => {
-    const result = GetUsersByOrgParamsSchema.safeParse({ orgId: 'foo' });
-    expect(result.success).toBe(false);
-    expect(result.error?.issues).toEqual([
-      {
-        code: 'invalid_value',
-        values: ['site', 'school', 'class', 'cohort'],
-        message:
-          'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
-        path: ['orgType'],
-      },
-    ]);
-  });
-
-  it('rejects missing orgId', () => {
-    const result = GetUsersByOrgParamsSchema.safeParse({ orgType: 'site' });
-    expect(result.success).toBe(false);
-    expect(result.error?.issues).toEqual([
-      {
-        code: 'invalid_type',
-        expected: 'string',
-        message: 'Invalid input: expected string, received undefined',
-        path: ['orgId'],
-      },
-    ]);
-  });
-
-  it('rejects an empty orgId', () => {
-    const result = GetUsersByOrgParamsSchema.safeParse({
-      orgType: 'site',
-      orgId: '   ',
+    it('rejects missing orgType', () => {
+      const result = GetUsersByOrgParamsSchema.safeParse({ orgId: 'foo' });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'invalid_value',
+          values: ['site', 'school', 'class', 'cohort'],
+          message:
+            'Invalid option: expected one of "site"|"school"|"class"|"cohort"',
+          path: ['orgType'],
+        },
+      ]);
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.issues).toEqual([
-      {
-        code: 'too_small',
-        inclusive: true,
-        message: 'Too small: expected string to have >=1 characters',
-        origin: 'string',
-        minimum: 1,
-        path: ['orgId'],
-      },
-    ]);
+  });
+
+  describe('orgId', () => {
+    it('rejects missing orgId', () => {
+      const result = GetUsersByOrgParamsSchema.safeParse({ orgType: 'site' });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Invalid input: expected string, received undefined',
+          path: ['orgId'],
+        },
+      ]);
+    });
+
+    it('rejects an empty orgId', () => {
+      const result = GetUsersByOrgParamsSchema.safeParse({
+        orgType: 'site',
+        orgId: '   ',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        {
+          code: 'too_small',
+          inclusive: true,
+          message: 'Too small: expected string to have >=1 characters',
+          origin: 'string',
+          minimum: 1,
+          path: ['orgId'],
+        },
+      ]);
+    });
   });
 });
 
@@ -121,75 +113,22 @@ describe('GetUsersByOrgErrorSchema', () => {
     });
   });
 
-  describe('functions/internal', () => {
-    it('accepts a valid org-site-missing error', () => {
-      const err = new FunctionsError('internal', 'Org site missing', {
-        code: 'org-site-missing',
-        orgType: 'school',
-        orgId: 'foo',
-        siteId: 'bar',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+  it('accepts functions/internal/org-site-missing error', () => {
+    const err = new FunctionsError('internal', 'Org site missing', {
+      code: 'org-site-missing',
+      orgType: 'school',
+      orgId: 'foo',
+      siteId: 'bar',
     });
-
-    it('rejects an unknown details code', () => {
-      const err = new FunctionsError('internal', 'Org site missing', {
-        code: 'unknown',
-        orgType: 'school',
-        orgId: 'foo',
-        siteId: 'bar',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
-    });
-
-    it('rejects a missing siteId', () => {
-      const err = new FunctionsError('internal', 'Org site missing', {
-        code: 'org-site-missing',
-        orgType: 'school',
-        orgId: 'foo',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
-    });
+    expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
   });
 
-  describe('functions/not-found', () => {
-    it('accepts a valid org not-found error', () => {
-      const err = new FunctionsError('not-found', 'Org not found', {
-        code: 'org',
-        id: 'foo',
-        type: 'site',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
+  it('accepts functions/not-found/org error', () => {
+    const err = new FunctionsError('not-found', 'Org not found', {
+      code: 'org',
+      id: 'foo',
+      type: 'site',
     });
-
-    it.each(['site', 'school', 'class', 'cohort'] as const)(
-      'accepts org type "%s"',
-      (type) => {
-        const err = new FunctionsError('not-found', 'Org not found', {
-          code: 'org',
-          id: 'foo',
-          type,
-        });
-        expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
-      },
-    );
-
-    it('rejects an unknown details code', () => {
-      const err = new FunctionsError('not-found', 'Org not found', {
-        code: 'user',
-        id: 'foo',
-        type: 'site',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
-    });
-
-    it('rejects an invalid org type', () => {
-      const err = new FunctionsError('not-found', 'Org not found', {
-        code: 'org',
-        id: 'foo',
-        type: 'district',
-      });
-      expect(() => GetUsersByOrgErrorSchema.parse(err)).toThrow();
-    });
+    expect(() => GetUsersByOrgErrorSchema.parse(err)).not.toThrow();
   });
 });

--- a/src/firebase-functions/get-users-by-org.ts
+++ b/src/firebase-functions/get-users-by-org.ts
@@ -1,0 +1,48 @@
+import * as z from 'zod';
+import { NonEmptyStringSchema } from '../shared/non-empty-string';
+import {
+  FunctionsErrorSchema,
+  InvalidArgumentErrorSchema,
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+} from './error';
+
+/** Parameters schema for `getUsersByOrg` Firebase Function. */
+export const GetUsersByOrgParamsSchema = z.object({
+  orgType: z.enum(['site', 'school', 'class', 'cohort']),
+  orgId: NonEmptyStringSchema,
+});
+
+/** Inferred type of {@link GetUsersByOrgParamsSchema}. */
+export type GetUsersByOrgParams = z.infer<typeof GetUsersByOrgParamsSchema>;
+
+/** Wire format representation of a Firestore `users/{uid}` doc. */
+export type SerializedUser = {
+  uid: string;
+  email: string;
+  userType: 'admin' | 'caregiver' | 'child' | 'teacher';
+  childLabelIndex?: number;
+};
+
+/** Result type for `getUsersByOrg` Firebase Function. */
+export type GetUsersByOrgResult = {
+  users: SerializedUser[];
+};
+
+/** Error schema for `getUsersByOrg` Firebase Function. */
+export const GetUsersByOrgErrorSchema = z.discriminatedUnion('code', [
+  InvalidArgumentErrorSchema,
+  FunctionsErrorSchema.extend({
+    code: z.literal('functions/not-found'),
+    details: z.object({
+      code: z.literal('org'),
+      id: z.string(),
+      type: z.enum(['site', 'school', 'class', 'cohort']),
+    }),
+  }),
+  PermissionDeniedErrorSchema,
+  UnauthenticatedErrorSchema,
+]);
+
+/** Inferred type of {@link GetUsersByOrgErrorSchema}. */
+export type GetUsersByOrgError = z.infer<typeof GetUsersByOrgErrorSchema>;

--- a/src/firebase-functions/get-users-by-org.ts
+++ b/src/firebase-functions/get-users-by-org.ts
@@ -33,6 +33,15 @@ export type GetUsersByOrgResult = {
 export const GetUsersByOrgErrorSchema = z.discriminatedUnion('code', [
   InvalidArgumentErrorSchema,
   FunctionsErrorSchema.extend({
+    code: z.literal('functions/internal'),
+    details: z.object({
+      code: z.literal('org-site-missing'),
+      orgType: z.string(),
+      orgId: z.string(),
+      siteId: z.string(),
+    }),
+  }),
+  FunctionsErrorSchema.extend({
     code: z.literal('functions/not-found'),
     details: z.object({
       code: z.literal('org'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ import {
   GetSyncStatusErrorSchema,
   GetSyncStatusParamsSchema,
 } from './firebase-functions/get-sync-status';
+import {
+  GetUsersByOrgErrorSchema,
+  GetUsersByOrgParamsSchema,
+} from './firebase-functions/get-users-by-org';
 import { makeCustomIssue } from './util/issues';
 
 // Type alias for Firestore Timestamp
@@ -538,6 +542,8 @@ export {
   GetSiteOverviewParamsSchema,
   GetSyncStatusErrorSchema,
   GetSyncStatusParamsSchema,
+  GetUsersByOrgErrorSchema,
+  GetUsersByOrgParamsSchema,
   GroupSchema,
   H3CellSchema,
   LatLonSourceSchema,
@@ -615,6 +621,11 @@ export type {
   GetSyncStatusParams,
   GetSyncStatusResult,
 } from './firebase-functions/get-sync-status';
+export type {
+  GetUsersByOrgError,
+  GetUsersByOrgParams,
+  GetUsersByOrgResult,
+} from './firebase-functions/get-users-by-org';
 export type GroupType = z.infer<typeof GroupSchema>;
 export type LatLonSourceType = z.infer<typeof LatLonSourceSchema>;
 export type LegalInfoType = z.infer<typeof LegalInfoSchema>;


### PR DESCRIPTION
## Summary

Adds Zod schemas and TypeScript types for the `getUsersByOrg` Firebase Function.

This is meant to be a bridge PR in order to refactor dashboard's `getOrgUsers` to use a Firebase Functions callable instead a Firestore REST call; it only captures the `users` fields that the dashboard currently consumes. This should be merged first, then #27 should be rebased such that it only introduces the changes related to `archived`/`disabled` handling and/or pagination.